### PR TITLE
Fix geos interop memory leaks

### DIFF
--- a/spatial/include/spatial/geos/geos_wrappers.hpp
+++ b/spatial/include/spatial/geos/geos_wrappers.hpp
@@ -183,6 +183,10 @@ struct WKTReader {
 		reader = GEOSWKTReader_create_r(ctx);
 	}
 
+	~WKTReader() {
+		GEOSWKTReader_destroy_r(ctx, reader);
+	}
+
 	GeometryPtr Read(string_t &wkt) const {
 		auto str = wkt.GetString();
 		auto geom = GEOSWKTReader_read_r(ctx, reader, str.c_str());
@@ -199,6 +203,10 @@ struct WKTWriter {
 
 	explicit WKTWriter(GEOSContextHandle_t ctx) : ctx(ctx) {
 		writer = GEOSWKTWriter_create_r(ctx);
+	}
+
+	~WKTWriter() {
+		GEOSWKTWriter_destroy_r(ctx, writer);
 	}
 
 	void SetTrim(bool trim) const {


### PR DESCRIPTION
When constructing GEOS geometries out of our own we create temporary arrays of pointers to subcomponents such as linear rings for polygons and child geometries for collections. GEOS takes ownership of the pointers, but not the arrays themselves which we forgot to free.

We we're also missing a couple of destructors in some of our wrappers, like WKTReader/WKTWriter.