### PR TITLE
Fix extension-upload.sh

### DIFF
--- a/scripts/extension-upload.sh
+++ b/scripts/extension-upload.sh
@@ -58,9 +58,9 @@ cat $ext.sign >> $ext.append
 
 # compress extension binary
 if [[ $4 == wasm_* ]]; then
-  gzip < $ext.append > "$ext.compressed"
-else
   brotli < $ext.append > "$ext.compressed"
+else
+  gzip < $ext.append > "$ext.compressed"
 fi
 
 set -e


### PR DESCRIPTION
DuckDB-Wasm extension are brotli compressed, DuckDB regular extensions are gzip compressed. I had moved those lines around, and there was no easy way to test this (but to have an uniform script that's well tested across our extensions).

I took the liberty of uploading the spatial.duckdb_extension.wasm (uncompressing as gzip, then compressing as brotli) to the main extension repository, and it works as expected!!

Current main limitation seems to be that fetching remote files is not working properly for all file types, I guess it's connected to the various file-system layers, will take a proper look.