### PR TITLE
Loop multiple Read if they do not fill all the requested buffer

### DIFF
--- a/spatial/src/spatial/gdal/file_handler.cpp
+++ b/spatial/src/spatial/gdal/file_handler.cpp
@@ -44,10 +44,19 @@ public:
 		}
 		return 0;
 	}
+
 	size_t Read(void *pBuffer, size_t nSize, size_t nCount) override {
-		auto read_bytes = file_handle->Read(pBuffer, nSize * nCount);
-		// Return the number of items read
-		return static_cast<size_t>(read_bytes / nSize);
+		auto remaining_bytes = nSize * nCount;
+		while(remaining_bytes > 0) {
+			auto read_bytes = file_handle->Read(pBuffer, remaining_bytes);
+			if(read_bytes == 0) {
+				break;
+			}
+			remaining_bytes -= read_bytes;
+			// Note we performed a cast back to void*
+			pBuffer = static_cast<uint8_t*>(pBuffer) + read_bytes;
+		}
+		return nCount - (remaining_bytes / nSize);
 	}
 
 	int Eof() override {


### PR DESCRIPTION
With @Maxxen.

Issue that lead to look into this was that shapelib bails out if a read do not fill the buffer completely, while GDALFileSystem (and other filesystems downstream) will potentially return only partial reads (case in point that triggered that was the duckdb-wasm filesystem). Solution is to make so that GDAL Read takes responsibility for filling the buffer.

I have a live tests where loading spatial with this modification makes complete the query successfully.