### PR TITLE
Misc bugfixes

### DIFF
--- a/spatial/include/spatial/geos/geos_executor.hpp
+++ b/spatial/include/spatial/geos/geos_executor.hpp
@@ -34,8 +34,8 @@ struct GEOSExecutor {
 		auto &ctx = lstate.ctx.GetCtx();
 
 		if (left.GetVectorType() == VectorType::CONSTANT_VECTOR &&
-		    right.GetVectorType() != VectorType::CONSTANT_VECTOR) {
-			auto &left_blob = FlatVector::GetData<string_t>(left)[0];
+		    right.GetVectorType() != VectorType::CONSTANT_VECTOR && !ConstantVector::IsNull(left)) {
+			auto &left_blob = ConstantVector::GetData<string_t>(left)[0];
 			auto left_geom = lstate.ctx.Deserialize(left_blob);
 			auto left_prepared = make_uniq_geos(ctx, GEOSPrepare_r(ctx, left_geom.get()));
 
@@ -45,8 +45,8 @@ struct GEOSExecutor {
 				return ok == 1;
 			});
 		} else if (right.GetVectorType() == VectorType::CONSTANT_VECTOR &&
-		           left.GetVectorType() != VectorType::CONSTANT_VECTOR) {
-			auto &right_blob = FlatVector::GetData<string_t>(right)[0];
+		           left.GetVectorType() != VectorType::CONSTANT_VECTOR && !ConstantVector::IsNull(right)) {
+			auto &right_blob = ConstantVector::GetData<string_t>(right)[0];
 			auto right_geom = lstate.ctx.Deserialize(right_blob);
 			auto right_prepared = make_uniq_geos(ctx, GEOSPrepare_r(ctx, right_geom.get()));
 
@@ -75,8 +75,8 @@ struct GEOSExecutor {
 
 		// Optimize: if one of the arguments is a constant, we can prepare it once and reuse it
 		if (left.GetVectorType() == VectorType::CONSTANT_VECTOR &&
-		    right.GetVectorType() != VectorType::CONSTANT_VECTOR) {
-			auto &left_blob = FlatVector::GetData<string_t>(left)[0];
+		    right.GetVectorType() != VectorType::CONSTANT_VECTOR && !ConstantVector::IsNull(left)) {
+			auto &left_blob = ConstantVector::GetData<string_t>(left)[0];
 			auto left_geom = lstate.ctx.Deserialize(left_blob);
 			auto left_prepared = make_uniq_geos(ctx, GEOSPrepare_r(ctx, left_geom.get()));
 

--- a/spatial/src/spatial/core/functions/scalar/st_asgeojson.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_asgeojson.cpp
@@ -218,24 +218,24 @@ static Point PointFromGeoJSON(yyjson_val *coord_array, GeometryFactory &factory,
 	if (len == 0) {
 		// empty point
 		return factory.CreateEmptyPoint();
-	} else if (len == 2) {
-		auto x_val = yyjson_arr_get_first(coord_array);
-		if (!yyjson_is_num(x_val)) {
-			throw InvalidInputException("GeoJSON input coordinates field is not an array of numbers: %s",
-			                            raw.GetString());
-		}
-		auto y_val = yyjson_arr_get_last(coord_array);
-		if (!yyjson_is_num(y_val)) {
-			throw InvalidInputException("GeoJSON input coordinates field is not an array of numbers: %s",
-			                            raw.GetString());
-		}
-		auto x = yyjson_get_num(x_val);
-		auto y = yyjson_get_num(y_val);
-		return factory.CreatePoint(x, y);
-	} else {
-		throw InvalidInputException("GeoJSON input coordinates field is not an array of length 2 or 0: %s",
-		                            raw.GetString());
 	}
+    if(len < 2) {
+        throw InvalidInputException("GeoJSON input coordinates field is not an array of at least length 2: %s",
+                                raw.GetString());
+    }
+    auto x_val = yyjson_arr_get_first(coord_array);
+    if (!yyjson_is_num(x_val)) {
+        throw InvalidInputException("GeoJSON input coordinates field is not an array of numbers: %s",
+                                    raw.GetString());
+    }
+    auto y_val = len == 2 ? yyjson_arr_get_last(coord_array) : yyjson_arr_get(coord_array, 1);
+    if (!yyjson_is_num(y_val)) {
+        throw InvalidInputException("GeoJSON input coordinates field is not an array of numbers: %s",
+                                    raw.GetString());
+    }
+    auto x = yyjson_get_num(x_val);
+    auto y = yyjson_get_num(y_val);
+    return factory.CreatePoint(x, y);
 }
 
 static VertexVector VerticesFromGeoJSON(yyjson_val *coord_array, GeometryFactory &factory, const string_t &raw) {
@@ -252,8 +252,8 @@ static VertexVector VerticesFromGeoJSON(yyjson_val *coord_array, GeometryFactory
 				                            raw.GetString());
 			}
 			auto coord_len = yyjson_arr_size(coord_val);
-			if (coord_len != 2) {
-				throw InvalidInputException("GeoJSON input coordinates field is not an array of arrays of length 2: %s",
+			if (coord_len < 2) {
+				throw InvalidInputException("GeoJSON input coordinates field is not an array of arrays of length >= 2: %s",
 				                            raw.GetString());
 			}
 			auto x_val = yyjson_arr_get_first(coord_val);
@@ -261,7 +261,7 @@ static VertexVector VerticesFromGeoJSON(yyjson_val *coord_array, GeometryFactory
 				throw InvalidInputException("GeoJSON input coordinates field is not an array of arrays of numbers: %s",
 				                            raw.GetString());
 			}
-			auto y_val = yyjson_arr_get_last(coord_val);
+			auto y_val = coord_len == 2 ? yyjson_arr_get_last(coord_val) : yyjson_arr_get(coord_val, 1);
 			if (!yyjson_is_num(y_val)) {
 				throw InvalidInputException("GeoJSON input coordinates field is not an array of arrays of numbers: %s",
 				                            raw.GetString());
@@ -315,8 +315,8 @@ static MultiPoint MultiPointFromGeoJSON(yyjson_val *coord_array, GeometryFactory
 				throw InvalidInputException("GeoJSON input coordinates field is not an array of arrays: %s",
 				                            raw.GetString());
 			}
-			if (yyjson_arr_size(point_val) != 2) {
-				throw InvalidInputException("GeoJSON input coordinates field is not an array of arrays of length 2: %s",
+			if (yyjson_arr_size(point_val) < 2) {
+				throw InvalidInputException("GeoJSON input coordinates field is not an array of arrays of length >= 2: %s",
 				                            raw.GetString());
 			}
 			multi_point[idx] = PointFromGeoJSON(point_val, factory, raw);

--- a/spatial/src/spatial/geographiclib/functions/st_area_spheroid.cpp
+++ b/spatial/src/spatial/geographiclib/functions/st_area_spheroid.cpp
@@ -13,6 +13,8 @@
 #include "GeographicLib/Geodesic.hpp"
 #include "GeographicLib/PolygonArea.hpp"
 
+#include "cmath"
+
 namespace spatial {
 
 namespace geographiclib {
@@ -59,14 +61,14 @@ static void GeodesicPolygon2DFunction(DataChunk &args, ExpressionState &state, V
 			polygon_area.Compute(false, true, _perimeter, ring_area);
 			if (first) {
 				// Add outer ring
-				area = ring_area;
+				area += std::abs(ring_area);
 				first = false;
 			} else {
 				// Subtract holes
-				area -= ring_area;
+				area -= std::abs(ring_area);
 			}
 		}
-		return area;
+		return std::abs(area);
 	});
 
 	if (count == 1) {
@@ -78,7 +80,6 @@ static void GeodesicPolygon2DFunction(DataChunk &args, ExpressionState &state, V
 // GEOMETRY
 //------------------------------------------------------------------------------
 static double PolygonArea(const core::Polygon &poly, GeographicLib::PolygonArea &comp) {
-
 	double total_area = 0;
 	for (uint32_t ring_idx = 0; ring_idx < poly.Count(); ring_idx++) {
 		comp.Clear();
@@ -90,16 +91,17 @@ static double PolygonArea(const core::Polygon &poly, GeographicLib::PolygonArea 
 		}
 		double ring_area;
 		double _perimeter;
+        // We use the absolute value here so that the actual winding order of the polygon rings dont matter.
 		comp.Compute(false, true, _perimeter, ring_area);
 		if (ring_idx == 0) {
 			// Add outer ring
-			total_area = ring_area;
+			total_area += std::abs(ring_area);
 		} else {
 			// Subtract holes
-			total_area -= ring_area;
+			total_area -= std::abs(ring_area);
 		}
 	}
-	return total_area;
+	return std::abs(total_area);
 }
 
 static double GeometryArea(const core::Geometry &geom, GeographicLib::PolygonArea &comp) {

--- a/spatial/src/spatial/proj/module.cpp
+++ b/spatial/src/spatial/proj/module.cpp
@@ -35,6 +35,12 @@ PJ_CONTEXT *ProjModule::GetThreadProjContext() {
 		throw InternalException("Could not set proj.db path");
 	}
 
+    // Dont log errors to stderr
+    proj_log_level(ctx, PJ_LOG_NONE);
+
+    // Dont allow network
+    proj_context_set_enable_network(ctx, false);
+
 	return ctx;
 }
 

--- a/test/sql/geometry/st_asgeojson.test
+++ b/test/sql/geometry/st_asgeojson.test
@@ -57,3 +57,28 @@ MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((2 2, 3 2, 3 3, 2 3, 2 2)))
 GEOMETRYCOLLECTION EMPTY
 GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 1 1))
 
+
+
+# Test that we can read with 3 dimensions
+query I
+SELECT ST_GeomFromGeoJSON('{"type":"Point","coordinates":[1.0,2.0,3.0]}');
+----
+POINT (1 2)
+
+#linestring
+query I
+SELECT ST_GeomFromGeoJSON('{"type":"LineString","coordinates":[[1.0,2.0,3.0],[4.0,5.0,6.0]]}');
+----
+LINESTRING (1 2, 4 5)
+
+# polygon
+query I
+SELECT ST_GeomFromGeoJSON('{"type":"Polygon","coordinates":[[[1.0,2.0,3.0],[4.0,5.0,6.0],[7.0,8.0,9.0],[1.0,2.0,3.0]]]}');
+----
+POLYGON ((1 2, 4 5, 7 8, 1 2))
+
+query I
+SELECT ST_GeomFromGeoJSON('{"type":"MultiPoint","coordinates":[[1.0,2.0,3.0],[4.0,5.0,6.0]]}');
+----
+MULTIPOINT (1 2, 4 5)
+

--- a/test/sql/geometry/st_disjoint.test
+++ b/test/sql/geometry/st_disjoint.test
@@ -1,0 +1,20 @@
+require spatial
+
+# https://github.com/duckdb/duckdb_spatial/issues/204
+
+statement ok
+DROP TABLE IF EXISTS origin;
+
+statement ok
+CREATE TABLE origin (id int, geom geometry);
+
+statement ok
+INSERT INTO origin (id, geom) VALUES (0, ST_Boundary(ST_GeomFromText('GEOMETRYCOLLECTION EMPTY')));
+
+statement ok
+INSERT INTO origin (id, geom) VALUES (1, ST_Boundary(ST_GeomFromText('MULTILINESTRING((7 33,4 31 ,9 31 ,13 27 ,7 33))')));
+
+query I
+SELECT ST_Disjoint(a1.geom, a2.geom) FROM origin as a1, origin as a2 WHERE a1.id = 1 and a2.id = 0;
+----
+NULL

--- a/test/sql/st_area_spheroid.test
+++ b/test/sql/st_area_spheroid.test
@@ -1,0 +1,27 @@
+require spatial
+# belem box (lat, lon)
+# -1.475781,-48.516655,-1.403706,-48.433228
+# 'POLYGON((-1.475781 -48.516655, -1.475781 -48.433228, -1.403706 -48.433228, -1.403706 -48.516655, -1.475781 -48.516655))'
+
+statement ok
+CREATE TABLE polys (cw GEOMETRY, ccw GEOMETRY);
+
+# Store two polygons, one clockwise, one counter-clockwise, both in EPSG:4326 with lat/lon coordinate axis order
+statement ok
+INSERT INTO polys SELECT * FROM (
+	SELECT
+		'POLYGON((-1.475781 -48.516655, -1.475781 -48.433228, -1.403706 -48.433228, -1.403706 -48.516655, -1.475781 -48.516655))'::GEOMETRY as cw,
+		ST_Reverse(cw) as ccw
+);
+
+# Use the spheroid area calculation
+query II
+SELECT ST_Area_Spheroid(cw), ST_Area_Spheroid(ccw) FROM polys;
+----
+73991730	73991730
+
+# Use the planar area calculation
+query II
+SELECT ST_Area(ST_Transform(cw, 'EPSG:4326', 'EPSG:3857')), ST_Area(ST_Transform(ccw, 'EPSG:4326', 'EPSG:3857')) FROM polys;
+----
+74536819	74536819


### PR DESCRIPTION
- Fixed ST_Area_Spheroid not handling holes properly
- Fixed GEOS relation functions not handling constant null vectors properly
- ST_Transform will no longer log to stdout when erroring
- Relaxed `ST_GeomFromGeoJSON` to accept coordinate arrays with more than two elements. Since DuckDB spatial does not yet support multidimensional geometries additional elements are ignored.

Closes #224 
Closes #204
Closes #205