### PR TITLE
Fix StableDistributionPipeline

### DIFF
--- a/.github/workflows/StableDistributionPipeline.yml
+++ b/.github/workflows/StableDistributionPipeline.yml
@@ -38,4 +38,4 @@ jobs:
     with:
       duckdb_version: v0.10.0
       extension_name: spatial
-      deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+      deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/v0.10.0' }}


### PR DESCRIPTION
This is needed since otherwise writing to the bucket would not be triggered (given the branch will NOT be called main).

This would also need to be merged on branch v0.10.0