### PR TITLE
Move to duckdb/extension-ci-tools actions

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -24,16 +24,15 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/duckdb/.github/workflows/_extension_distribution.yml@3fbbd15390059b8028ad6dfd56a3172e5ebc0ab8
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
-      vcpkg_commit: a42af01b72c28a8e1d7b48107b33e4f286a55ef6
       duckdb_version: main
       extension_name: spatial
 
   duckdb-stable-deploy:
     name: Deploy extension binaries
     needs: duckdb-stable-build
-    uses: duckdb/duckdb/.github/workflows/_extension_deploy.yml@3fbbd15390059b8028ad6dfd56a3172e5ebc0ab8
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@main
     secrets: inherit
     with:
       duckdb_version: main

--- a/.github/workflows/StableDistributionPipeline.yml
+++ b/.github/workflows/StableDistributionPipeline.yml
@@ -24,16 +24,15 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/duckdb/.github/workflows/_extension_distribution.yml@3fbbd15390059b8028ad6dfd56a3172e5ebc0ab8
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v0.10.0
     with:
-      vcpkg_commit: a42af01b72c28a8e1d7b48107b33e4f286a55ef6
       duckdb_version: v0.10.0
       extension_name: spatial
 
   duckdb-stable-deploy:
     name: Deploy extension binaries
     needs: duckdb-stable-build
-    uses: duckdb/duckdb/.github/workflows/_extension_deploy.yml@3fbbd15390059b8028ad6dfd56a3172e5ebc0ab8
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v0.10.0
     secrets: inherit
     with:
       duckdb_version: v0.10.0


### PR DESCRIPTION
More fun with GH actions, now pointing workflows to https://github.com/duckdb/extension-ci-tools.