### PR TITLE
Use direct IO when reading remote files through GDAL, Fix Big-Endian WKB reading

### DIFF
--- a/spatial/include/spatial/core/geometry/bbox.hpp
+++ b/spatial/include/spatial/core/geometry/bbox.hpp
@@ -21,42 +21,42 @@ struct BoundingBox {
 		return !(minx > other.maxx || maxx < other.minx || miny > other.maxy || maxy < other.miny);
 	}
 
-    // Update the bounding box to include the specified vertex
-    void Stretch(const VertexXY &vertex) {
-        minx = std::min(minx, vertex.x);
-        miny = std::min(miny, vertex.y);
-        maxx = std::max(maxx, vertex.x);
-        maxy = std::max(maxy, vertex.y);
-    }
+	// Update the bounding box to include the specified vertex
+	void Stretch(const VertexXY &vertex) {
+		minx = std::min(minx, vertex.x);
+		miny = std::min(miny, vertex.y);
+		maxx = std::max(maxx, vertex.x);
+		maxy = std::max(maxy, vertex.y);
+	}
 
-    void Stretch(const VertexXYZ &vertex) {
-        minx = std::min(minx, vertex.x);
-        miny = std::min(miny, vertex.y);
-        maxx = std::max(maxx, vertex.x);
-        maxy = std::max(maxy, vertex.y);
-        minz = std::min(minz, vertex.z);
-        maxz = std::max(maxz, vertex.z);
-    }
+	void Stretch(const VertexXYZ &vertex) {
+		minx = std::min(minx, vertex.x);
+		miny = std::min(miny, vertex.y);
+		maxx = std::max(maxx, vertex.x);
+		maxy = std::max(maxy, vertex.y);
+		minz = std::min(minz, vertex.z);
+		maxz = std::max(maxz, vertex.z);
+	}
 
-    void Stretch(const VertexXYM &vertex) {
-        minx = std::min(minx, vertex.x);
-        miny = std::min(miny, vertex.y);
-        maxx = std::max(maxx, vertex.x);
-        maxy = std::max(maxy, vertex.y);
-        minm = std::min(minm, vertex.m);
-        maxm = std::max(maxm, vertex.m);
-    }
+	void Stretch(const VertexXYM &vertex) {
+		minx = std::min(minx, vertex.x);
+		miny = std::min(miny, vertex.y);
+		maxx = std::max(maxx, vertex.x);
+		maxy = std::max(maxy, vertex.y);
+		minm = std::min(minm, vertex.m);
+		maxm = std::max(maxm, vertex.m);
+	}
 
-    void Stretch(const VertexXYZM &vertex) {
-        minx = std::min(minx, vertex.x);
-        miny = std::min(miny, vertex.y);
-        maxx = std::max(maxx, vertex.x);
-        maxy = std::max(maxy, vertex.y);
-        minz = std::min(minz, vertex.z);
-        maxz = std::max(maxz, vertex.z);
-        minm = std::min(minm, vertex.m);
-        maxm = std::max(maxm, vertex.m);
-    }
+	void Stretch(const VertexXYZM &vertex) {
+		minx = std::min(minx, vertex.x);
+		miny = std::min(miny, vertex.y);
+		maxx = std::max(maxx, vertex.x);
+		maxy = std::max(maxy, vertex.y);
+		minz = std::min(minz, vertex.z);
+		maxz = std::max(maxz, vertex.z);
+		minm = std::min(minm, vertex.m);
+		maxm = std::max(maxm, vertex.m);
+	}
 };
 
 } // namespace core

--- a/spatial/include/spatial/core/geometry/cursor.hpp
+++ b/spatial/include/spatial/core/geometry/cursor.hpp
@@ -52,6 +52,27 @@ public:
 	}
 
 	template <class T>
+	T ReadBigEndian() {
+		static_assert(std::is_floating_point<T>::value || std::is_integral<T>::value,
+		              "T must be a floating point or integral type");
+		if (ptr + sizeof(T) > end) {
+			throw SerializationException("Trying to read past end of buffer");
+		}
+
+		uint8_t in[sizeof(T)];
+		uint8_t out[sizeof(T)];
+		memcpy(in, ptr, sizeof(T));
+		ptr += sizeof(T);
+
+		for (size_t i = 0; i < sizeof(T); i++) {
+			out[i] = in[sizeof(T) - i - 1];
+		}
+		T swapped = 0;
+		memcpy(&swapped, out, sizeof(T));
+		return swapped;
+	}
+
+	template <class T>
 	void Write(T value) {
 		static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable");
 		if (ptr + sizeof(T) > end) {

--- a/spatial/include/spatial/core/geometry/geometry.hpp
+++ b/spatial/include/spatial/core/geometry/geometry.hpp
@@ -21,72 +21,83 @@ class Geometry;
 //------------------------------------------------------------------------------
 
 class BaseGeometry {
-    friend class Geometry;
+	friend class Geometry;
+
 protected:
-    GeometryType type;
-    GeometryProperties properties;
-    bool is_readonly;
-    uint32_t data_count;
-    union {
-        Geometry *part_data;
-        data_ptr_t vertex_data;
-    } data;
+	GeometryType type;
+	GeometryProperties properties;
+	bool is_readonly;
+	uint32_t data_count;
+	union {
+		Geometry *part_data;
+		data_ptr_t vertex_data;
+	} data;
 
-    BaseGeometry(GeometryType type, Geometry *part_data, bool is_readonly, bool has_z, bool has_m)
-        : type(type), properties(has_z, has_m), is_readonly(is_readonly), data_count(0), data({nullptr}){
-        data.part_data = part_data;
-    }
+	BaseGeometry(GeometryType type, Geometry *part_data, bool is_readonly, bool has_z, bool has_m)
+	    : type(type), properties(has_z, has_m), is_readonly(is_readonly), data_count(0), data({nullptr}) {
+		data.part_data = part_data;
+	}
 
-    BaseGeometry(GeometryType type, data_ptr_t vert_data, bool is_readonly, bool has_z, bool has_m)
-        : type(type), properties(has_z, has_m), is_readonly(is_readonly), data_count(0), data({nullptr}) {
-        data.vertex_data = vert_data;
-    }
+	BaseGeometry(GeometryType type, data_ptr_t vert_data, bool is_readonly, bool has_z, bool has_m)
+	    : type(type), properties(has_z, has_m), is_readonly(is_readonly), data_count(0), data({nullptr}) {
+		data.vertex_data = vert_data;
+	}
 
-    // Copy Constructor
-    BaseGeometry(const BaseGeometry &other)
-        : type(other.type), properties(other.properties), is_readonly(true), data_count(other.data_count), data({nullptr}) {
-        data = other.data;
-    }
+	// Copy Constructor
+	BaseGeometry(const BaseGeometry &other)
+	    : type(other.type), properties(other.properties), is_readonly(true), data_count(other.data_count),
+	      data({nullptr}) {
+		data = other.data;
+	}
 
-    // Copy Assignment
-    BaseGeometry &operator=(const BaseGeometry &other) {
-        type = other.type;
-        properties = other.properties;
-        is_readonly = true;
-        data_count = other.data_count;
-        data = other.data;
-        return *this;
-    }
+	// Copy Assignment
+	BaseGeometry &operator=(const BaseGeometry &other) {
+		type = other.type;
+		properties = other.properties;
+		is_readonly = true;
+		data_count = other.data_count;
+		data = other.data;
+		return *this;
+	}
 
-    // Move Constructor
-    BaseGeometry(BaseGeometry &&other) noexcept
-        : type(other.type), properties(other.properties), is_readonly(other.is_readonly), data_count(other.data_count), data({nullptr}) {
-        data = other.data;
-        if(!other.is_readonly) {
-            // Take ownership of the data, and make the other object read-only
-            other.is_readonly = true;
-        }
-    }
+	// Move Constructor
+	BaseGeometry(BaseGeometry &&other) noexcept
+	    : type(other.type), properties(other.properties), is_readonly(other.is_readonly), data_count(other.data_count),
+	      data({nullptr}) {
+		data = other.data;
+		if (!other.is_readonly) {
+			// Take ownership of the data, and make the other object read-only
+			other.is_readonly = true;
+		}
+	}
 
-    // Move Assignment
-    BaseGeometry &operator=(BaseGeometry &&other) noexcept {
-        type = other.type;
-        properties = other.properties;
-        is_readonly = other.is_readonly;
-        data_count = other.data_count;
-        data = other.data;
-        if(!other.is_readonly) {
-            // Take ownership of the data, and make the other object read-only
-            other.is_readonly = true;
-        }
-        return *this;
-    }
+	// Move Assignment
+	BaseGeometry &operator=(BaseGeometry &&other) noexcept {
+		type = other.type;
+		properties = other.properties;
+		is_readonly = other.is_readonly;
+		data_count = other.data_count;
+		data = other.data;
+		if (!other.is_readonly) {
+			// Take ownership of the data, and make the other object read-only
+			other.is_readonly = true;
+		}
+		return *this;
+	}
 
 public:
-    GeometryProperties GetProperties() const { return properties; }
-    GeometryProperties &GetProperties() { return properties; }
-    bool IsReadOnly() const { return is_readonly; }
-    uint32_t Count() const { return data_count; }
+	GeometryProperties GetProperties() const {
+		return properties;
+	}
+	GeometryProperties &GetProperties() {
+		return properties;
+	}
+	bool IsReadOnly() const {
+		return is_readonly;
+	}
+	uint32_t Count() const {
+		return data_count;
+	}
 };
 
 static_assert(sizeof(BaseGeometry) <= 16, "GeometryBase should be at most 16 bytes (can be less in WASM)");
@@ -97,154 +108,162 @@ static_assert(sizeof(BaseGeometry) <= 16, "GeometryBase should be at most 16 byt
 
 // A single part geometry, contains a single array of vertices
 class SinglePartGeometry : public BaseGeometry {
-    friend class Geometry;
+	friend class Geometry;
+
 protected:
+	SinglePartGeometry(GeometryType type, bool has_z, bool has_m)
+	    : BaseGeometry(type, (data_ptr_t) nullptr, true, has_z, has_m) {
+	}
 
-    SinglePartGeometry(GeometryType type, bool has_z, bool has_m)
-        : BaseGeometry(type, (data_ptr_t) nullptr, true, has_z, has_m) {}
-
-    SinglePartGeometry(GeometryType type, ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
-        : BaseGeometry(type, (data_ptr_t) nullptr, false, has_z, has_m) {
-        data_count = count;
-        data.vertex_data = alloc.AllocateAligned(count * properties.VertexSize());
-    }
+	SinglePartGeometry(GeometryType type, ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
+	    : BaseGeometry(type, (data_ptr_t) nullptr, false, has_z, has_m) {
+		data_count = count;
+		data.vertex_data = alloc.AllocateAligned(count * properties.VertexSize());
+	}
 
 public:
-    uint32_t ByteSize() const { return data_count * properties.VertexSize(); }
+	uint32_t ByteSize() const {
+		return data_count * properties.VertexSize();
+	}
 
-    bool IsEmpty() const { return data_count == 0; }
+	bool IsEmpty() const {
+		return data_count == 0;
+	}
 
-    const_data_ptr_t GetData() const { return data.vertex_data; }
+	const_data_ptr_t GetData() const {
+		return data.vertex_data;
+	}
 
-    void Set(uint32_t index, const VertexXY &vertex) {
-        D_ASSERT(index < data_count);
-        Store(vertex, data.vertex_data + index * properties.VertexSize());
-    }
+	void Set(uint32_t index, const VertexXY &vertex) {
+		D_ASSERT(index < data_count);
+		Store(vertex, data.vertex_data + index * properties.VertexSize());
+	}
 
-    void Set(uint32_t index, double x, double y) {
-        Set(index, VertexXY {x, y});
-    }
+	void Set(uint32_t index, double x, double y) {
+		Set(index, VertexXY {x, y});
+	}
 
-    VertexXY Get(uint32_t index) const {
-        D_ASSERT(index < data_count);
-        return Load<VertexXY>(data.vertex_data + index * properties.VertexSize());
-    }
+	VertexXY Get(uint32_t index) const {
+		D_ASSERT(index < data_count);
+		return Load<VertexXY>(data.vertex_data + index * properties.VertexSize());
+	}
 
-    template<class V>
-    void SetExact(uint32_t index, const V &vertex) {
-        static_assert(V::IS_VERTEX, "V must be a vertex type");
-        D_ASSERT(V::HAS_Z == properties.HasZ());
-        D_ASSERT(V::HAS_M == properties.HasM());
-        D_ASSERT(index < data_count);
-        Store(vertex, data.vertex_data + index * sizeof(V));
-    }
+	template <class V>
+	void SetExact(uint32_t index, const V &vertex) {
+		static_assert(V::IS_VERTEX, "V must be a vertex type");
+		D_ASSERT(V::HAS_Z == properties.HasZ());
+		D_ASSERT(V::HAS_M == properties.HasM());
+		D_ASSERT(index < data_count);
+		Store(vertex, data.vertex_data + index * sizeof(V));
+	}
 
-    template<class V>
-    V GetExact(uint32_t index) const {
-        static_assert(V::IS_VERTEX, "V must be a vertex type");
-        D_ASSERT(V::HAS_Z == properties.HasZ());
-        D_ASSERT(V::HAS_M == properties.HasM());
-        D_ASSERT(index < data_count);
-        return Load<V>(data.vertex_data + index * sizeof(V));
-    }
+	template <class V>
+	V GetExact(uint32_t index) const {
+		static_assert(V::IS_VERTEX, "V must be a vertex type");
+		D_ASSERT(V::HAS_Z == properties.HasZ());
+		D_ASSERT(V::HAS_M == properties.HasM());
+		D_ASSERT(index < data_count);
+		return Load<V>(data.vertex_data + index * sizeof(V));
+	}
 
-    // Turn this geometry into a read-only reference to another geometry, starting at the specified index
-    void Reference(const SinglePartGeometry &other, uint32_t offset, uint32_t count);
+	// Turn this geometry into a read-only reference to another geometry, starting at the specified index
+	void Reference(const SinglePartGeometry &other, uint32_t offset, uint32_t count);
 
-    // Turn this geometry into a read-only reference to raw data
-    void ReferenceData(const_data_ptr_t data, uint32_t count, bool has_z, bool has_m);
+	// Turn this geometry into a read-only reference to raw data
+	void ReferenceData(const_data_ptr_t data, uint32_t count, bool has_z, bool has_m);
 
-    void ReferenceData(const_data_ptr_t data, uint32_t count) {
-        ReferenceData(data, count, properties.HasZ(), properties.HasM());
-    }
+	void ReferenceData(const_data_ptr_t data, uint32_t count) {
+		ReferenceData(data, count, properties.HasZ(), properties.HasM());
+	}
 
-    // Turn this geometry into a owning copy of another geometry, starting at the specified index
-    void Copy(ArenaAllocator& alloc, const SinglePartGeometry &other, uint32_t offset, uint32_t count);
+	// Turn this geometry into a owning copy of another geometry, starting at the specified index
+	void Copy(ArenaAllocator &alloc, const SinglePartGeometry &other, uint32_t offset, uint32_t count);
 
-    // Turn this geometry into a owning copy of raw data
-    void CopyData(ArenaAllocator& alloc, const_data_ptr_t data, uint32_t count, bool has_z, bool has_m);
+	// Turn this geometry into a owning copy of raw data
+	void CopyData(ArenaAllocator &alloc, const_data_ptr_t data, uint32_t count, bool has_z, bool has_m);
 
-    void CopyData(ArenaAllocator& alloc, const_data_ptr_t data, uint32_t count) {
-        CopyData(alloc, data, count, properties.HasZ(), properties.HasM());
-    }
+	void CopyData(ArenaAllocator &alloc, const_data_ptr_t data, uint32_t count) {
+		CopyData(alloc, data, count, properties.HasZ(), properties.HasM());
+	}
 
-    // Resize the geometry, truncating or extending with zeroed vertices as needed
-    void Resize(ArenaAllocator &alloc, uint32_t new_count);
+	// Resize the geometry, truncating or extending with zeroed vertices as needed
+	void Resize(ArenaAllocator &alloc, uint32_t new_count);
 
-    // Append the data from another geometry
-    void Append(ArenaAllocator &alloc, const SinglePartGeometry& other);
+	// Append the data from another geometry
+	void Append(ArenaAllocator &alloc, const SinglePartGeometry &other);
 
-    // Append the data from multiple other geometries
-    void Append(ArenaAllocator &alloc, const SinglePartGeometry* others, uint32_t others_count);
+	// Append the data from multiple other geometries
+	void Append(ArenaAllocator &alloc, const SinglePartGeometry *others, uint32_t others_count);
 
-    // Force the geometry to have a specific vertex type, resizing or shrinking the data as needed
-    void SetVertexType(ArenaAllocator &alloc, bool has_z, bool has_m, double default_z = 0, double default_m = 0);
+	// Force the geometry to have a specific vertex type, resizing or shrinking the data as needed
+	void SetVertexType(ArenaAllocator &alloc, bool has_z, bool has_m, double default_z = 0, double default_m = 0);
 
-    // If this geometry is read-only, make it mutable by copying the data
-    void MakeMutable(ArenaAllocator &alloc);
+	// If this geometry is read-only, make it mutable by copying the data
+	void MakeMutable(ArenaAllocator &alloc);
 
-    // Print this geometry as a string, starting at the specified index and printing the specified number of vertices
-    // (useful for debugging)
-    string ToString(uint32_t start = 0, uint32_t count = 0) const;
+	// Print this geometry as a string, starting at the specified index and printing the specified number of vertices
+	// (useful for debugging)
+	string ToString(uint32_t start = 0, uint32_t count = 0) const;
 
-    // Check if the geometry is closed (first and last vertex are the same)
-    // A geometry with 1 vertex is considered closed, 0 vertices are considered open
-    bool IsClosed() const;
+	// Check if the geometry is closed (first and last vertex are the same)
+	// A geometry with 1 vertex is considered closed, 0 vertices are considered open
+	bool IsClosed() const;
 
-    // Return the planar length of the geometry
-    double Length() const;
+	// Return the planar length of the geometry
+	double Length() const;
 };
 
 // A multi-part geometry, contains multiple parts
 class MultiPartGeometry : public BaseGeometry {
 protected:
+	MultiPartGeometry(GeometryType type, bool has_z, bool has_m)
+	    : BaseGeometry(type, (Geometry *)nullptr, true, has_z, has_m) {
+	}
 
-    MultiPartGeometry(GeometryType type, bool has_z, bool has_m)
-        : BaseGeometry(type, (Geometry*) nullptr, true, has_z, has_m) {}
+	MultiPartGeometry(GeometryType type, ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
+	    : BaseGeometry(type, (Geometry *)nullptr, false, has_z, has_m) {
+		data_count = count;
+		data.vertex_data = alloc.AllocateAligned(count * sizeof(BaseGeometry));
+	}
 
-    MultiPartGeometry(GeometryType type, ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
-        : BaseGeometry(type, (Geometry*) nullptr, false, has_z, has_m) {
-            data_count = count;
-            data.vertex_data = alloc.AllocateAligned(count * sizeof(BaseGeometry));
-        }
 public:
+	bool IsEmpty() const;
 
-    bool IsEmpty() const;
+	Geometry &operator[](uint32_t index);
+	Geometry *begin();
+	Geometry *end();
 
-    Geometry &operator[](uint32_t index);
-    Geometry *begin();
-    Geometry *end();
+	const Geometry &operator[](uint32_t index) const;
+	const Geometry *begin() const;
+	const Geometry *end() const;
 
-    const Geometry &operator[](uint32_t index) const;
-    const Geometry *begin() const;
-    const Geometry *end() const;
-
-    void Resize(ArenaAllocator &alloc, uint32_t new_count);
+	void Resize(ArenaAllocator &alloc, uint32_t new_count);
 };
 
 class CollectionGeometry : public MultiPartGeometry {
 protected:
-    CollectionGeometry(GeometryType type, bool has_z, bool has_m)
-        : MultiPartGeometry(type, has_z, has_m) {}
-    CollectionGeometry(GeometryType type, ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
-        : MultiPartGeometry(type, alloc, count, has_z, has_m) {}
+	CollectionGeometry(GeometryType type, bool has_z, bool has_m) : MultiPartGeometry(type, has_z, has_m) {
+	}
+	CollectionGeometry(GeometryType type, ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
+	    : MultiPartGeometry(type, alloc, count, has_z, has_m) {
+	}
 };
 
-template<class T>
+template <class T>
 class TypedCollectionGeometry : public CollectionGeometry {
 protected:
-    TypedCollectionGeometry(GeometryType type, bool has_z, bool has_m)
-        : CollectionGeometry(type, has_z, has_m) {}
-    TypedCollectionGeometry(GeometryType type, ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m);
+	TypedCollectionGeometry(GeometryType type, bool has_z, bool has_m) : CollectionGeometry(type, has_z, has_m) {
+	}
+	TypedCollectionGeometry(GeometryType type, ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m);
 
 public:
-    T &operator[](uint32_t index);
-    T* begin();
-    T* end();
+	T &operator[](uint32_t index);
+	T *begin();
+	T *end();
 
-    const T &operator[](uint32_t index) const;
-    const T *begin() const;
-    const T *end() const;
+	const T &operator[](uint32_t index) const;
+	const T *begin() const;
+	const T *end() const;
 };
 
 //------------------------------------------------------------------------------
@@ -254,416 +273,460 @@ public:
 
 class Point : public SinglePartGeometry {
 public:
-    static constexpr GeometryType TYPE = GeometryType::POINT;
+	static constexpr GeometryType TYPE = GeometryType::POINT;
 
-    Point(bool has_z = false, bool has_m = false) : SinglePartGeometry(TYPE, has_z, has_m) {}
-    Point(ArenaAllocator &alloc, bool has_z, bool has_m) : SinglePartGeometry(TYPE, alloc, 1, has_z, has_m) {}
+	Point(bool has_z = false, bool has_m = false) : SinglePartGeometry(TYPE, has_z, has_m) {
+	}
+	Point(ArenaAllocator &alloc, bool has_z, bool has_m) : SinglePartGeometry(TYPE, alloc, 1, has_z, has_m) {
+	}
 
-    // Helpers
-    template<class V>
-    static Point FromVertex(ArenaAllocator &alloc, const V &vertex) {
-        static_assert(V::IS_VERTEX, "V must be a vertex type");
-        Point point(alloc, V::HAS_Z, V::HAS_M);
-        point.SetExact(0, vertex);
-        return point;
-    }
+	// Helpers
+	template <class V>
+	static Point FromVertex(ArenaAllocator &alloc, const V &vertex) {
+		static_assert(V::IS_VERTEX, "V must be a vertex type");
+		Point point(alloc, V::HAS_Z, V::HAS_M);
+		point.SetExact(0, vertex);
+		return point;
+	}
 
-    static Point CopyFromData(ArenaAllocator &alloc, const_data_ptr_t data, uint32_t count, bool has_z, bool has_m) {
-        Point point(alloc, has_z, has_m);
-        point.CopyData(alloc, data, 1);
-        return point;
-    }
+	static Point CopyFromData(ArenaAllocator &alloc, const_data_ptr_t data, uint32_t count, bool has_z, bool has_m) {
+		Point point(alloc, has_z, has_m);
+		point.CopyData(alloc, data, 1);
+		return point;
+	}
 
-    static Point FromReference(const SinglePartGeometry &other, uint32_t offset) {
-        Point point(other.GetProperties().HasZ(), other.GetProperties().HasM());
-        point.Reference(other, offset, 1);
-        return point;
-    }
+	static Point FromReference(const SinglePartGeometry &other, uint32_t offset) {
+		Point point(other.GetProperties().HasZ(), other.GetProperties().HasM());
+		point.Reference(other, offset, 1);
+		return point;
+	}
 };
 
 class LineString : public SinglePartGeometry {
 public:
-    static constexpr GeometryType TYPE = GeometryType::LINESTRING;
+	static constexpr GeometryType TYPE = GeometryType::LINESTRING;
 
-    LineString(bool has_z = false, bool has_m = false) : SinglePartGeometry(TYPE, has_z, has_m) {}
-    LineString(ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
-        : SinglePartGeometry(TYPE, alloc, count, has_z, has_m) {}
+	LineString(bool has_z = false, bool has_m = false) : SinglePartGeometry(TYPE, has_z, has_m) {
+	}
+	LineString(ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
+	    : SinglePartGeometry(TYPE, alloc, count, has_z, has_m) {
+	}
 
-    static LineString CopyFromData(ArenaAllocator &alloc, const_data_ptr_t data, uint32_t count, bool has_z, bool has_m) {
-        LineString line(alloc, count, has_z, has_m);
-        line.CopyData(alloc, data, count);
-        return line;
-    }
+	static LineString CopyFromData(ArenaAllocator &alloc, const_data_ptr_t data, uint32_t count, bool has_z,
+	                               bool has_m) {
+		LineString line(alloc, count, has_z, has_m);
+		line.CopyData(alloc, data, count);
+		return line;
+	}
 };
 
 class Polygon : public MultiPartGeometry {
 public:
-    static constexpr GeometryType TYPE = GeometryType::POLYGON;
+	static constexpr GeometryType TYPE = GeometryType::POLYGON;
 
-    Polygon(bool has_z = false, bool has_m = false) : MultiPartGeometry(TYPE, has_z, has_m) {}
-    Polygon(ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m);
+	Polygon(bool has_z = false, bool has_m = false) : MultiPartGeometry(TYPE, has_z, has_m) {
+	}
+	Polygon(ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m);
 
-    LineString &operator[](uint32_t index);
-    LineString* begin();
-    LineString* end();
+	LineString &operator[](uint32_t index);
+	LineString *begin();
+	LineString *end();
 
-    const LineString &operator[](uint32_t index) const;
-    const LineString* begin() const;
-    const LineString* end() const;
+	const LineString &operator[](uint32_t index) const;
+	const LineString *begin() const;
+	const LineString *end() const;
 
-    // TODO: Generalize this to take a min/max vertex instead
-    static Polygon FromBox(ArenaAllocator &alloc, double minx, double miny, double maxx, double maxy) {
-        Polygon box(alloc, 1, false, false);
-        auto &ring = box[0];
-        ring.Resize(alloc, 5);
-        ring.SetExact(0, VertexXY { minx, miny });
-        ring.SetExact(1, VertexXY { minx, maxy });
-        ring.SetExact(2, VertexXY { maxx, maxy });
-        ring.SetExact(3, VertexXY { maxx, miny });
-        ring.SetExact(4, VertexXY { minx, miny });
-        return box;
-    }
+	// TODO: Generalize this to take a min/max vertex instead
+	static Polygon FromBox(ArenaAllocator &alloc, double minx, double miny, double maxx, double maxy) {
+		Polygon box(alloc, 1, false, false);
+		auto &ring = box[0];
+		ring.Resize(alloc, 5);
+		ring.SetExact(0, VertexXY {minx, miny});
+		ring.SetExact(1, VertexXY {minx, maxy});
+		ring.SetExact(2, VertexXY {maxx, maxy});
+		ring.SetExact(3, VertexXY {maxx, miny});
+		ring.SetExact(4, VertexXY {minx, miny});
+		return box;
+	}
 };
 
 class MultiPoint : public TypedCollectionGeometry<Point> {
 public:
-    static constexpr GeometryType TYPE = GeometryType::MULTIPOINT;
+	static constexpr GeometryType TYPE = GeometryType::MULTIPOINT;
 
-    MultiPoint(bool has_z = false, bool has_m = false) : TypedCollectionGeometry(TYPE, has_z, has_m) {}
-    MultiPoint(ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
-        : TypedCollectionGeometry(TYPE, alloc, count, has_z, has_m) {}
+	MultiPoint(bool has_z = false, bool has_m = false) : TypedCollectionGeometry(TYPE, has_z, has_m) {
+	}
+	MultiPoint(ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
+	    : TypedCollectionGeometry(TYPE, alloc, count, has_z, has_m) {
+	}
 };
 
 class MultiLineString : public TypedCollectionGeometry<LineString> {
 public:
-    static constexpr GeometryType TYPE = GeometryType::MULTILINESTRING;
+	static constexpr GeometryType TYPE = GeometryType::MULTILINESTRING;
 
-    MultiLineString(bool has_z = false, bool has_m = false) : TypedCollectionGeometry(TYPE, has_z, has_m) {}
-    MultiLineString(ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
-        : TypedCollectionGeometry(TYPE, alloc, count, has_z, has_m) {}
+	MultiLineString(bool has_z = false, bool has_m = false) : TypedCollectionGeometry(TYPE, has_z, has_m) {
+	}
+	MultiLineString(ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
+	    : TypedCollectionGeometry(TYPE, alloc, count, has_z, has_m) {
+	}
 };
 
 class MultiPolygon : public TypedCollectionGeometry<Polygon> {
 public:
-    static constexpr GeometryType TYPE = GeometryType::MULTIPOLYGON;
+	static constexpr GeometryType TYPE = GeometryType::MULTIPOLYGON;
 
-    MultiPolygon(bool has_z = false, bool has_m = false) : TypedCollectionGeometry(TYPE, has_z, has_m) {}
-    MultiPolygon(ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
-        : TypedCollectionGeometry(TYPE, alloc, count, has_z, has_m) {}
+	MultiPolygon(bool has_z = false, bool has_m = false) : TypedCollectionGeometry(TYPE, has_z, has_m) {
+	}
+	MultiPolygon(ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
+	    : TypedCollectionGeometry(TYPE, alloc, count, has_z, has_m) {
+	}
 };
 
-class GeometryCollection : public CollectionGeometry  {
+class GeometryCollection : public CollectionGeometry {
 public:
-    static constexpr GeometryType TYPE = GeometryType::GEOMETRYCOLLECTION;
+	static constexpr GeometryType TYPE = GeometryType::GEOMETRYCOLLECTION;
 
-    GeometryCollection(bool has_z = false, bool has_m = false) : CollectionGeometry(TYPE, has_z, has_m) {}
-    GeometryCollection(ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m);
+	GeometryCollection(bool has_z = false, bool has_m = false) : CollectionGeometry(TYPE, has_z, has_m) {
+	}
+	GeometryCollection(ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m);
 };
 
 class Geometry {
-    union {
-        Point point;
-        LineString linestring;
-        Polygon polygon;
-        MultiPoint multipoint;
-        MultiLineString multilinestring;
-        MultiPolygon multipolygon;
-        GeometryCollection collection;
-    };
+	union {
+		Point point;
+		LineString linestring;
+		Polygon polygon;
+		MultiPoint multipoint;
+		MultiLineString multilinestring;
+		MultiPolygon multipolygon;
+		GeometryCollection collection;
+	};
+
 public:
+	// This is legal because all members is standard layout and have the same common initial sequence
+	// Additionally, a union is pointer-interconvertible with its first member
+	GeometryType GetType() const {
+		return point.type;
+	}
+	GeometryProperties GetProperties() const {
+		return point.properties;
+	}
+	GeometryProperties &GetProperties() {
+		return point.properties;
+	}
+	bool IsReadOnly() const {
+		return reinterpret_cast<const BaseGeometry &>(*this).IsReadOnly();
+	}
+	bool IsCollection() const {
+		auto type = GetType();
+		return type == GeometryType::MULTIPOINT || type == GeometryType::MULTILINESTRING ||
+		       type == GeometryType::MULTIPOLYGON || type == GeometryType::GEOMETRYCOLLECTION;
+	}
 
-    // This is legal because all members is standard layout and have the same common initial sequence
-    // Additionally, a union is pointer-interconvertible with its first member
-    GeometryType GetType() const { return point.type; }
-    GeometryProperties GetProperties() const { return point.properties; }
-    GeometryProperties &GetProperties() { return point.properties; }
-    bool IsReadOnly() const { return reinterpret_cast<const BaseGeometry&>(*this).IsReadOnly(); }
-    bool IsCollection() const {
-        auto type = GetType();
-        return type == GeometryType::MULTIPOINT || type == GeometryType::MULTILINESTRING
-            || type == GeometryType::MULTIPOLYGON || type == GeometryType::GEOMETRYCOLLECTION;
-    }
+	// NOLINTBEGIN
+	Geometry(Point point) : point(point) {
+	}
+	Geometry(LineString linestring) : linestring(linestring) {
+	}
+	Geometry(Polygon polygon) : polygon(polygon) {
+	}
+	Geometry(MultiPoint multipoint) : multipoint(multipoint) {
+	}
+	Geometry(MultiLineString multilinestring) : multilinestring(multilinestring) {
+	}
+	Geometry(MultiPolygon multipolygon) : multipolygon(multipolygon) {
+	}
+	Geometry(GeometryCollection collection) : collection(collection) {
+	}
+	// NOLINTEND
 
-    // NOLINTBEGIN
-    Geometry(Point point) : point(point) {}
-    Geometry(LineString linestring) : linestring(linestring) {}
-    Geometry(Polygon polygon) : polygon(polygon) {}
-    Geometry(MultiPoint multipoint) : multipoint(multipoint) {}
-    Geometry(MultiLineString multilinestring) : multilinestring(multilinestring) {}
-    Geometry(MultiPolygon multipolygon) : multipolygon(multipolygon) {}
-    Geometry(GeometryCollection collection) : collection(collection) {}
-    // NOLINTEND
+	// Copy Constructor
+	Geometry(const Geometry &other) {
+		switch (other.GetType()) {
+		case GeometryType::POINT:
+			new (&point) Point(other.point);
+			break;
+		case GeometryType::LINESTRING:
+			new (&linestring) LineString(other.linestring);
+			break;
+		case GeometryType::POLYGON:
+			new (&polygon) Polygon(other.polygon);
+			break;
+		case GeometryType::MULTIPOINT:
+			new (&multipoint) MultiPoint(other.multipoint);
+			break;
+		case GeometryType::MULTILINESTRING:
+			new (&multilinestring) MultiLineString(other.multilinestring);
+			break;
+		case GeometryType::MULTIPOLYGON:
+			new (&multipolygon) MultiPolygon(other.multipolygon);
+			break;
+		case GeometryType::GEOMETRYCOLLECTION:
+			new (&collection) GeometryCollection(other.collection);
+			break;
+		default:
+			throw NotImplementedException("Geometry::Geometry(const Geometry&)");
+		}
+	}
 
+	// Copy Assignment
+	Geometry &operator=(const Geometry &other) {
+		if (this == &other) {
+			return *this;
+		}
+		this->~Geometry();
+		switch (other.GetType()) {
+		case GeometryType::POINT:
+			new (&point) Point(other.point);
+			break;
+		case GeometryType::LINESTRING:
+			new (&linestring) LineString(other.linestring);
+			break;
+		case GeometryType::POLYGON:
+			new (&polygon) Polygon(other.polygon);
+			break;
+		case GeometryType::MULTIPOINT:
+			new (&multipoint) MultiPoint(other.multipoint);
+			break;
+		case GeometryType::MULTILINESTRING:
+			new (&multilinestring) MultiLineString(other.multilinestring);
+			break;
+		case GeometryType::MULTIPOLYGON:
+			new (&multipolygon) MultiPolygon(other.multipolygon);
+			break;
+		case GeometryType::GEOMETRYCOLLECTION:
+			new (&collection) GeometryCollection(other.collection);
+			break;
+		default:
+			throw NotImplementedException("Geometry::operator=(const Geometry&)");
+		}
+		return *this;
+	}
 
-    // Copy Constructor
-    Geometry(const Geometry& other) {
-        switch (other.GetType()) {
-            case GeometryType::POINT:
-                new(&point) Point(other.point);
-                break;
-            case GeometryType::LINESTRING:
-                new(&linestring) LineString(other.linestring);
-                break;
-            case GeometryType::POLYGON:
-                new(&polygon) Polygon(other.polygon);
-                break;
-            case GeometryType::MULTIPOINT:
-                new(&multipoint) MultiPoint(other.multipoint);
-                break;
-            case GeometryType::MULTILINESTRING:
-                new(&multilinestring) MultiLineString(other.multilinestring);
-                break;
-            case GeometryType::MULTIPOLYGON:
-                new(&multipolygon) MultiPolygon(other.multipolygon);
-                break;
-            case GeometryType::GEOMETRYCOLLECTION:
-                new(&collection) GeometryCollection(other.collection);
-                break;
-            default:
-                throw NotImplementedException("Geometry::Geometry(const Geometry&)");
-        }
-    }
+	// Move Constructor
+	Geometry(Geometry &&other) noexcept {
+		switch (other.GetType()) {
+		case GeometryType::POINT:
+			new (&point) Point(std::move(other.point));
+			break;
+		case GeometryType::LINESTRING:
+			new (&linestring) LineString(std::move(other.linestring));
+			break;
+		case GeometryType::POLYGON:
+			new (&polygon) Polygon(std::move(other.polygon));
+			break;
+		case GeometryType::MULTIPOINT:
+			new (&multipoint) MultiPoint(std::move(other.multipoint));
+			break;
+		case GeometryType::MULTILINESTRING:
+			new (&multilinestring) MultiLineString(std::move(other.multilinestring));
+			break;
+		case GeometryType::MULTIPOLYGON:
+			new (&multipolygon) MultiPolygon(std::move(other.multipolygon));
+			break;
+		case GeometryType::GEOMETRYCOLLECTION:
+			new (&collection) GeometryCollection(std::move(other.collection));
+			break;
+		default:
+			D_ASSERT(false);
+			new (&point) Point(std::move(other.point));
+			break;
+		}
+	}
 
-    // Copy Assignment
-    Geometry &operator=(const Geometry &other) {
-        if (this == &other) {
-            return *this;
-        }
-        this->~Geometry();
-        switch (other.GetType()) {
-            case GeometryType::POINT:
-                new(&point) Point(other.point);
-                break;
-            case GeometryType::LINESTRING:
-                new(&linestring) LineString(other.linestring);
-                break;
-            case GeometryType::POLYGON:
-                new(&polygon) Polygon(other.polygon);
-                break;
-            case GeometryType::MULTIPOINT:
-                new(&multipoint) MultiPoint(other.multipoint);
-                break;
-            case GeometryType::MULTILINESTRING:
-                new(&multilinestring) MultiLineString(other.multilinestring);
-                break;
-            case GeometryType::MULTIPOLYGON:
-                new(&multipolygon) MultiPolygon(other.multipolygon);
-                break;
-            case GeometryType::GEOMETRYCOLLECTION:
-                new(&collection) GeometryCollection(other.collection);
-                break;
-            default:
-                throw NotImplementedException("Geometry::operator=(const Geometry&)");
-        }
-        return *this;
-    }
+	// Move Assignment
+	Geometry &operator=(Geometry &&other) noexcept {
+		if (this == &other) {
+			return *this;
+		}
+		this->~Geometry();
+		switch (other.GetType()) {
+		case GeometryType::POINT:
+			new (&point) Point(std::move(other.point));
+			break;
+		case GeometryType::LINESTRING:
+			new (&linestring) LineString(std::move(other.linestring));
+			break;
+		case GeometryType::POLYGON:
+			new (&polygon) Polygon(std::move(other.polygon));
+			break;
+		case GeometryType::MULTIPOINT:
+			new (&multipoint) MultiPoint(std::move(other.multipoint));
+			break;
+		case GeometryType::MULTILINESTRING:
+			new (&multilinestring) MultiLineString(std::move(other.multilinestring));
+			break;
+		case GeometryType::MULTIPOLYGON:
+			new (&multipolygon) MultiPolygon(std::move(other.multipolygon));
+			break;
+		case GeometryType::GEOMETRYCOLLECTION:
+			new (&collection) GeometryCollection(std::move(other.collection));
+			break;
+		default:
+			D_ASSERT(false);
+			new (&point) Point(std::move(other.point));
+			break;
+		}
+		return *this;
+	}
 
-    // Move Constructor
-    Geometry(Geometry &&other) noexcept {
-        switch (other.GetType()) {
-            case GeometryType::POINT:
-                new(&point) Point(std::move(other.point));
-                break;
-            case GeometryType::LINESTRING:
-                new(&linestring) LineString(std::move(other.linestring));
-                break;
-            case GeometryType::POLYGON:
-                new(&polygon) Polygon(std::move(other.polygon));
-                break;
-            case GeometryType::MULTIPOINT:
-                new(&multipoint) MultiPoint(std::move(other.multipoint));
-                break;
-            case GeometryType::MULTILINESTRING:
-                new(&multilinestring) MultiLineString(std::move(other.multilinestring));
-                break;
-            case GeometryType::MULTIPOLYGON:
-                new(&multipolygon) MultiPolygon(std::move(other.multipolygon));
-                break;
-            case GeometryType::GEOMETRYCOLLECTION:
-                new(&collection) GeometryCollection(std::move(other.collection));
-                break;
-            default:
-                D_ASSERT(false);
-                new(&point) Point(std::move(other.point));
-                break;
-        }
-    }
+	template <class T>
+	T &As() {
+		D_ASSERT(GetType() == T::TYPE);
+		return reinterpret_cast<T &>(*this);
+	}
 
-    // Move Assignment
-    Geometry &operator=(Geometry &&other) noexcept {
-        if (this == &other) {
-            return *this;
-        }
-        this->~Geometry();
-        switch (other.GetType()) {
-            case GeometryType::POINT:
-                new(&point) Point(std::move(other.point));
-                break;
-            case GeometryType::LINESTRING:
-                new(&linestring) LineString(std::move(other.linestring));
-                break;
-            case GeometryType::POLYGON:
-                new(&polygon) Polygon(std::move(other.polygon));
-                break;
-            case GeometryType::MULTIPOINT:
-                new(&multipoint) MultiPoint(std::move(other.multipoint));
-                break;
-            case GeometryType::MULTILINESTRING:
-                new(&multilinestring) MultiLineString(std::move(other.multilinestring));
-                break;
-            case GeometryType::MULTIPOLYGON:
-                new(&multipolygon) MultiPolygon(std::move(other.multipolygon));
-                break;
-            case GeometryType::GEOMETRYCOLLECTION:
-                new(&collection) GeometryCollection(std::move(other.collection));
-                break;
-            default:
-                D_ASSERT(false);
-                new(&point) Point(std::move(other.point));
-                break;
-        }
-        return *this;
-    }
+	template <class T>
+	const T &As() const {
+		D_ASSERT(GetType() == T::TYPE);
+		return reinterpret_cast<const T &>(*this);
+	}
 
-    template<class T>
-    T &As() {
-        D_ASSERT(GetType() == T::TYPE);
-        return reinterpret_cast<T&>(*this);
-    }
+	// Apply a functor to the contained geometry
+	template <class F, class... ARGS>
+	auto Visit(ARGS &&...args) const -> decltype(F::Apply(std::declval<const Point &>(), std::forward<ARGS>(args)...)) {
+		switch (GetType()) {
+		case GeometryType::POINT:
+			return F::Apply(const_cast<const Point &>(point), std::forward<ARGS>(args)...);
+		case GeometryType::LINESTRING:
+			return F::Apply(const_cast<const LineString &>(linestring), std::forward<ARGS>(args)...);
+		case GeometryType::POLYGON:
+			return F::Apply(const_cast<const Polygon &>(polygon), std::forward<ARGS>(args)...);
+		case GeometryType::MULTIPOINT:
+			return F::Apply(const_cast<const MultiPoint &>(multipoint), std::forward<ARGS>(args)...);
+		case GeometryType::MULTILINESTRING:
+			return F::Apply(const_cast<const MultiLineString &>(multilinestring), std::forward<ARGS>(args)...);
+		case GeometryType::MULTIPOLYGON:
+			return F::Apply(const_cast<const MultiPolygon &>(multipolygon), std::forward<ARGS>(args)...);
+		case GeometryType::GEOMETRYCOLLECTION:
+			return F::Apply(const_cast<const GeometryCollection &>(collection), std::forward<ARGS>(args)...);
+		default:
+			throw NotImplementedException("Geometry::Visit()");
+		}
+	}
 
-    template<class T>
-    const T &As() const {
-        D_ASSERT(GetType() == T::TYPE);
-        return reinterpret_cast<const T&>(*this);
-    }
+	// Apply a functor to the contained geometry
+	template <class F, class... ARGS>
+	auto Visit(ARGS &&...args) -> decltype(F::Apply(std::declval<Point &>(), std::forward<ARGS>(args)...)) {
+		switch (GetType()) {
+		case GeometryType::POINT:
+			return F::Apply(static_cast<Point &>(point), std::forward<ARGS>(args)...);
+		case GeometryType::LINESTRING:
+			return F::Apply(static_cast<LineString &>(linestring), std::forward<ARGS>(args)...);
+		case GeometryType::POLYGON:
+			return F::Apply(static_cast<Polygon &>(polygon), std::forward<ARGS>(args)...);
+		case GeometryType::MULTIPOINT:
+			return F::Apply(static_cast<MultiPoint &>(multipoint), std::forward<ARGS>(args)...);
+		case GeometryType::MULTILINESTRING:
+			return F::Apply(static_cast<MultiLineString &>(multilinestring), std::forward<ARGS>(args)...);
+		case GeometryType::MULTIPOLYGON:
+			return F::Apply(static_cast<MultiPolygon &>(multipolygon), std::forward<ARGS>(args)...);
+		case GeometryType::GEOMETRYCOLLECTION:
+			return F::Apply(static_cast<GeometryCollection &>(collection), std::forward<ARGS>(args)...);
+		default:
+			throw NotImplementedException("Geometry::Visit()");
+		}
+	}
 
-    // Apply a functor to the contained geometry
-    template <class F, class... ARGS>
-    auto Visit(ARGS &&...args) const
-    -> decltype(F::Apply(std::declval<const Point &>(), std::forward<ARGS>(args)...)) {
-        switch (GetType()) {
-            case GeometryType::POINT:
-                return F::Apply(const_cast<const Point &>(point), std::forward<ARGS>(args)...);
-            case GeometryType::LINESTRING:
-                return F::Apply(const_cast<const LineString &>(linestring), std::forward<ARGS>(args)...);
-            case GeometryType::POLYGON:
-                return F::Apply(const_cast<const Polygon &>(polygon), std::forward<ARGS>(args)...);
-            case GeometryType::MULTIPOINT:
-                return F::Apply(const_cast<const MultiPoint &>(multipoint), std::forward<ARGS>(args)...);
-            case GeometryType::MULTILINESTRING:
-                return F::Apply(const_cast<const MultiLineString &>(multilinestring), std::forward<ARGS>(args)...);
-            case GeometryType::MULTIPOLYGON:
-                return F::Apply(const_cast<const MultiPolygon &>(multipolygon), std::forward<ARGS>(args)...);
-            case GeometryType::GEOMETRYCOLLECTION:
-                return F::Apply(const_cast<const GeometryCollection &>(collection), std::forward<ARGS>(args)...);
-            default:
-                throw NotImplementedException("Geometry::Visit()");
-        }
-    }
+	uint32_t GetDimension(bool skip_empty) const {
+		if (skip_empty && IsEmpty()) {
+			return 0;
+		}
+		struct op {
+			static uint32_t Apply(const Point &, bool) {
+				return 0;
+			}
+			static uint32_t Apply(const LineString &, bool) {
+				return 1;
+			}
+			static uint32_t Apply(const Polygon &, bool) {
+				return 2;
+			}
+			static uint32_t Apply(const MultiPoint &, bool) {
+				return 0;
+			}
+			static uint32_t Apply(const MultiLineString &, bool) {
+				return 1;
+			}
+			static uint32_t Apply(const MultiPolygon &, bool) {
+				return 2;
+			}
+			static uint32_t Apply(const GeometryCollection &gc, bool skip_empty) {
+				uint32_t max = 0;
 
-    // Apply a functor to the contained geometry
-    template <class F, class... ARGS>
-    auto Visit(ARGS &&...args) -> decltype(F::Apply(std::declval<Point &>(), std::forward<ARGS>(args)...)) {
-        switch (GetType()) {
-            case GeometryType::POINT:
-                return F::Apply(static_cast<Point &>(point), std::forward<ARGS>(args)...);
-            case GeometryType::LINESTRING:
-                return F::Apply(static_cast<LineString &>(linestring), std::forward<ARGS>(args)...);
-            case GeometryType::POLYGON:
-                return F::Apply(static_cast<Polygon &>(polygon), std::forward<ARGS>(args)...);
-            case GeometryType::MULTIPOINT:
-                return F::Apply(static_cast<MultiPoint &>(multipoint), std::forward<ARGS>(args)...);
-            case GeometryType::MULTILINESTRING:
-                return F::Apply(static_cast<MultiLineString &>(multilinestring), std::forward<ARGS>(args)...);
-            case GeometryType::MULTIPOLYGON:
-                return F::Apply(static_cast<MultiPolygon &>(multipolygon), std::forward<ARGS>(args)...);
-            case GeometryType::GEOMETRYCOLLECTION:
-                return F::Apply(static_cast<GeometryCollection &>(collection), std::forward<ARGS>(args)...);
-            default:
-                throw NotImplementedException("Geometry::Visit()");
-        }
-    }
+				for (const auto &item : gc) {
+					max = std::max(max, item.GetDimension(skip_empty));
+				}
+				return max;
+			}
+		};
+		return Visit<op>(skip_empty);
+	}
 
-    uint32_t GetDimension(bool skip_empty) const {
-        if(skip_empty && IsEmpty()) {
-            return 0;
-        }
-        struct op {
-            static uint32_t Apply(const Point&, bool) { return 0; }
-            static uint32_t Apply(const LineString&, bool) { return 1; }
-            static uint32_t Apply(const Polygon&, bool) { return 2; }
-            static uint32_t Apply(const MultiPoint&, bool) { return 0; }
-            static uint32_t Apply(const MultiLineString&, bool) { return 1; }
-            static uint32_t Apply(const MultiPolygon&, bool) { return 2; }
-            static uint32_t Apply(const GeometryCollection &gc, bool skip_empty) {
-                uint32_t max = 0;
+	bool IsEmpty() const {
+		struct op {
+			static bool Apply(const SinglePartGeometry &g) {
+				return g.IsEmpty();
+			}
+			static bool Apply(const MultiPartGeometry &g) {
+				return g.IsEmpty();
+			}
+		};
+		return Visit<op>();
+	}
 
-                for (const auto &item : gc) {
-                    max = std::max(max, item.GetDimension(skip_empty));
-                }
-                return max;
-            }
-        };
-        return Visit<op>(skip_empty);
-    }
+	Geometry &SetVertexType(ArenaAllocator &arena, bool has_z, bool has_m, double default_z = 0, double default_m = 0) {
+		struct op {
+			static void Apply(SinglePartGeometry &g, ArenaAllocator &arena, bool has_z, bool has_m, double default_z,
+			                  double default_m) {
+				g.SetVertexType(arena, has_z, has_m);
+			}
+			static void Apply(MultiPartGeometry &g, ArenaAllocator &arena, bool has_z, bool has_m, double default_z,
+			                  double default_m) {
+				g.properties.SetZ(has_z);
+				g.properties.SetM(has_m);
+				for (auto &part : g) {
+					part.SetVertexType(arena, has_z, has_m, default_z, default_m);
+				}
+			}
+		};
+		Visit<op>(arena, has_z, has_m, default_z, default_m);
+		return *this;
+	}
 
-    bool IsEmpty() const {
-        struct op {
-            static bool Apply(const SinglePartGeometry &g) { return g.IsEmpty(); }
-            static bool Apply(const MultiPartGeometry &g) { return g.IsEmpty(); }
-        };
-        return Visit<op>();
-    }
-
-    Geometry& SetVertexType(ArenaAllocator &arena, bool has_z, bool has_m, double default_z = 0, double default_m = 0) {
-        struct op {
-            static void Apply(SinglePartGeometry &g, ArenaAllocator &arena, bool has_z, bool has_m, double default_z, double default_m) {
-                g.SetVertexType(arena, has_z, has_m);
-            }
-            static void Apply(MultiPartGeometry &g, ArenaAllocator &arena, bool has_z, bool has_m, double default_z, double default_m) {
-                g.properties.SetZ(has_z);
-                g.properties.SetM(has_m);
-                for (auto &part : g) {
-                    part.SetVertexType(arena, has_z, has_m, default_z, default_m);
-                }
-            }
-        };
-        Visit<op>(arena, has_z, has_m, default_z, default_m);
-        return *this;
-    }
-
-    geometry_t Serialize(Vector &result);
-    static Geometry Deserialize(ArenaAllocator &arena, const geometry_t &data);
+	geometry_t Serialize(Vector &result);
+	static Geometry Deserialize(ArenaAllocator &arena, const geometry_t &data);
 };
-
 
 //------------------------------------------------------------------------------
 // Inlined Methods
 //------------------------------------------------------------------------------
 
 inline Polygon::Polygon(ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
-        : MultiPartGeometry(TYPE, alloc, count, has_z, has_m) {
-        auto ptr = data.part_data;
-        for (uint32_t i = 0; i < count; i++) {
-        new(ptr++) LineString(alloc, 0, has_z, has_m);
-    }
+    : MultiPartGeometry(TYPE, alloc, count, has_z, has_m) {
+	auto ptr = data.part_data;
+	for (uint32_t i = 0; i < count; i++) {
+		new (ptr++) LineString(alloc, 0, has_z, has_m);
+	}
 }
 
 inline GeometryCollection::GeometryCollection(ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
-        : CollectionGeometry(TYPE, alloc, count, has_z, has_m) {
-        auto ptr = data.part_data;
-        for (uint32_t i = 0; i < count; i++) {
-        new(ptr++) Point(has_z, has_m);
-    }
+    : CollectionGeometry(TYPE, alloc, count, has_z, has_m) {
+	auto ptr = data.part_data;
+	for (uint32_t i = 0; i < count; i++) {
+		new (ptr++) Point(has_z, has_m);
+	}
 }
 
-template<class T>
-inline TypedCollectionGeometry<T>::TypedCollectionGeometry(GeometryType type, ArenaAllocator &alloc, uint32_t count, bool has_z, bool has_m)
+template <class T>
+inline TypedCollectionGeometry<T>::TypedCollectionGeometry(GeometryType type, ArenaAllocator &alloc, uint32_t count,
+                                                           bool has_z, bool has_m)
     : CollectionGeometry(type, alloc, count, has_z, has_m) {
-    auto ptr = data.part_data;
-    for (uint32_t i = 0; i < count; i++) {
-        new(ptr++) T(has_z, has_m);
-    }
+	auto ptr = data.part_data;
+	for (uint32_t i = 0; i < count; i++) {
+		new (ptr++) T(has_z, has_m);
+	}
 }
 
 //-------------------
@@ -671,53 +734,89 @@ inline TypedCollectionGeometry<T>::TypedCollectionGeometry(GeometryType type, Ar
 //-------------------
 
 inline bool MultiPartGeometry::IsEmpty() const {
-    for (const auto &part : *this) {
-        if (!part.IsEmpty()) {
-            return false;
-        }
-    }
-    return true;
+	for (const auto &part : *this) {
+		if (!part.IsEmpty()) {
+			return false;
+		}
+	}
+	return true;
 }
 
-inline Geometry& MultiPartGeometry::operator[](uint32_t index) { return data.part_data[index]; }
-inline Geometry* MultiPartGeometry::begin() { return data.part_data; }
-inline Geometry* MultiPartGeometry::end() { return data.part_data + data_count; }
+inline Geometry &MultiPartGeometry::operator[](uint32_t index) {
+	return data.part_data[index];
+}
+inline Geometry *MultiPartGeometry::begin() {
+	return data.part_data;
+}
+inline Geometry *MultiPartGeometry::end() {
+	return data.part_data + data_count;
+}
 
-inline const Geometry& MultiPartGeometry::operator[](uint32_t index) const { return data.part_data[index]; }
-inline const Geometry* MultiPartGeometry::begin() const { return data.part_data; }
-inline const Geometry* MultiPartGeometry::end() const { return data.part_data + data_count; }
+inline const Geometry &MultiPartGeometry::operator[](uint32_t index) const {
+	return data.part_data[index];
+}
+inline const Geometry *MultiPartGeometry::begin() const {
+	return data.part_data;
+}
+inline const Geometry *MultiPartGeometry::end() const {
+	return data.part_data + data_count;
+}
 
 //-----------------
 // Polygon
 //-----------------
 
-inline LineString& Polygon::operator[](uint32_t index) { return reinterpret_cast<LineString&>(data.part_data[index]); }
-inline LineString* Polygon::begin() { return reinterpret_cast<LineString*>(data.part_data); }
-inline LineString* Polygon::end() { return reinterpret_cast<LineString*>(data.part_data + data_count); }
+inline LineString &Polygon::operator[](uint32_t index) {
+	return reinterpret_cast<LineString &>(data.part_data[index]);
+}
+inline LineString *Polygon::begin() {
+	return reinterpret_cast<LineString *>(data.part_data);
+}
+inline LineString *Polygon::end() {
+	return reinterpret_cast<LineString *>(data.part_data + data_count);
+}
 
-inline const LineString& Polygon::operator[](uint32_t index) const { return reinterpret_cast<const LineString&>(data.part_data[index]); }
-inline const LineString* Polygon::begin() const { return reinterpret_cast<const LineString*>(data.part_data); }
-inline const LineString* Polygon::end() const { return reinterpret_cast<const LineString*>(data.part_data + data_count); }
+inline const LineString &Polygon::operator[](uint32_t index) const {
+	return reinterpret_cast<const LineString &>(data.part_data[index]);
+}
+inline const LineString *Polygon::begin() const {
+	return reinterpret_cast<const LineString *>(data.part_data);
+}
+inline const LineString *Polygon::end() const {
+	return reinterpret_cast<const LineString *>(data.part_data + data_count);
+}
 
 //-----------------
 // Collection
 //-----------------
 
-template<class T>
-inline T& TypedCollectionGeometry<T>::operator[](uint32_t index) { return reinterpret_cast<T&>(data.part_data[index]); }
-template<class T>
-inline T* TypedCollectionGeometry<T>::begin() { return reinterpret_cast<T*>(data.part_data); }
-template<class T>
-inline T* TypedCollectionGeometry<T>::end() { return reinterpret_cast<T*>(data.part_data + data_count); }
+template <class T>
+inline T &TypedCollectionGeometry<T>::operator[](uint32_t index) {
+	return reinterpret_cast<T &>(data.part_data[index]);
+}
+template <class T>
+inline T *TypedCollectionGeometry<T>::begin() {
+	return reinterpret_cast<T *>(data.part_data);
+}
+template <class T>
+inline T *TypedCollectionGeometry<T>::end() {
+	return reinterpret_cast<T *>(data.part_data + data_count);
+}
 
-template<class T>
-inline const T& TypedCollectionGeometry<T>::operator[](uint32_t index) const { return reinterpret_cast<const T&>(data.part_data[index]); }
+template <class T>
+inline const T &TypedCollectionGeometry<T>::operator[](uint32_t index) const {
+	return reinterpret_cast<const T &>(data.part_data[index]);
+}
 
-template<class T>
-inline const T* TypedCollectionGeometry<T>::begin() const { return reinterpret_cast<const T*>(data.part_data); }
+template <class T>
+inline const T *TypedCollectionGeometry<T>::begin() const {
+	return reinterpret_cast<const T *>(data.part_data);
+}
 
-template<class T>
-inline const T* TypedCollectionGeometry<T>::end() const { return reinterpret_cast<const T*>(data.part_data + data_count); }
+template <class T>
+inline const T *TypedCollectionGeometry<T>::end() const {
+	return reinterpret_cast<const T *>(data.part_data + data_count);
+}
 
 //------------------------------------------------------------------------------
 // Assertions
@@ -735,46 +834,45 @@ static_assert(std::is_standard_layout<MultiLineString>::value, "MultiLineString 
 static_assert(std::is_standard_layout<MultiPoint>::value, "MultiPoint must be standard layout");
 static_assert(std::is_standard_layout<GeometryCollection>::value, "GeometryCollection must be standard layout");
 
-
 //------------------------------------------------------------------------------
 // Utils
 //------------------------------------------------------------------------------
 
 struct Utils {
-    static string format_coord(double d);
-    static string format_coord(double x, double y);
-    static string format_coord(double x, double y, double z);
-    static string format_coord(double x, double y, double z, double m);
+	static string format_coord(double d);
+	static string format_coord(double x, double y);
+	static string format_coord(double x, double y, double z);
+	static string format_coord(double x, double y, double z, double m);
 
-    static inline float DoubleToFloatDown(double d) {
-        if (d > static_cast<double>(std::numeric_limits<float>::max())) {
-            return std::numeric_limits<float>::max();
-        }
-        if (d <= static_cast<double>(std::numeric_limits<float>::lowest())) {
-            return std::numeric_limits<float>::lowest();
-        }
+	static inline float DoubleToFloatDown(double d) {
+		if (d > static_cast<double>(std::numeric_limits<float>::max())) {
+			return std::numeric_limits<float>::max();
+		}
+		if (d <= static_cast<double>(std::numeric_limits<float>::lowest())) {
+			return std::numeric_limits<float>::lowest();
+		}
 
-        auto f = static_cast<float>(d);
-        if (static_cast<double>(f) <= d) {
-            return f;
-        }
-        return std::nextafter(f, std::numeric_limits<float>::lowest());
-    }
+		auto f = static_cast<float>(d);
+		if (static_cast<double>(f) <= d) {
+			return f;
+		}
+		return std::nextafter(f, std::numeric_limits<float>::lowest());
+	}
 
-    static inline float DoubleToFloatUp(double d) {
-        if (d >= static_cast<double>(std::numeric_limits<float>::max())) {
-            return std::numeric_limits<float>::max();
-        }
-        if (d < static_cast<double>(std::numeric_limits<float>::lowest())) {
-            return std::numeric_limits<float>::lowest();
-        }
+	static inline float DoubleToFloatUp(double d) {
+		if (d >= static_cast<double>(std::numeric_limits<float>::max())) {
+			return std::numeric_limits<float>::max();
+		}
+		if (d < static_cast<double>(std::numeric_limits<float>::lowest())) {
+			return std::numeric_limits<float>::lowest();
+		}
 
-        auto f = static_cast<float>(d);
-        if (static_cast<double>(f) >= d) {
-            return f;
-        }
-        return std::nextafter(f, std::numeric_limits<float>::max());
-    }
+		auto f = static_cast<float>(d);
+		if (static_cast<double>(f) >= d) {
+			return f;
+		}
+		return std::nextafter(f, std::numeric_limits<float>::max());
+	}
 };
 
 } // namespace core

--- a/spatial/include/spatial/core/geometry/geometry_properties.hpp
+++ b/spatial/include/spatial/core/geometry/geometry_properties.hpp
@@ -19,10 +19,10 @@ private:
 public:
 	explicit GeometryProperties(uint8_t flags = 0) : flags(flags) {
 	}
-    GeometryProperties(bool has_z, bool has_m) {
-        SetZ(has_z);
-        SetM(has_m);
-    }
+	GeometryProperties(bool has_z, bool has_m) {
+		SetZ(has_z);
+		SetM(has_m);
+	}
 
 	inline bool HasZ() const {
 		return (flags & Z) != 0;
@@ -43,7 +43,9 @@ public:
 		flags = value ? (flags | BBOX) : (flags & ~BBOX);
 	}
 
-    uint32_t VertexSize() const { return sizeof(double) * (2 + HasZ() + HasM()); }
+	uint32_t VertexSize() const {
+		return sizeof(double) * (2 + HasZ() + HasM());
+	}
 };
 
 } // namespace core

--- a/spatial/include/spatial/core/geometry/geometry_type.hpp
+++ b/spatial/include/spatial/core/geometry/geometry_type.hpp
@@ -54,50 +54,50 @@ public:
 		return Load<uint16_t>(const_data_ptr_cast(data.GetPrefix() + 2));
 	}
 
-    bool TryGetCachedBounds(BoundingBox &bbox) const {
-        Cursor cursor(data);
+	bool TryGetCachedBounds(BoundingBox &bbox) const {
+		Cursor cursor(data);
 
-        // Read the header
-        auto header_type = cursor.Read<GeometryType>();
-        auto properties = cursor.Read<GeometryProperties>();
-        auto hash = cursor.Read<uint16_t>();
-        (void)hash;
+		// Read the header
+		auto header_type = cursor.Read<GeometryType>();
+		auto properties = cursor.Read<GeometryProperties>();
+		auto hash = cursor.Read<uint16_t>();
+		(void)hash;
 
-        if (properties.HasBBox()) {
-            cursor.Skip(4); // skip padding
+		if (properties.HasBBox()) {
+			cursor.Skip(4); // skip padding
 
-            // Now set the bounding box
-            bbox.minx = cursor.Read<float>();
-            bbox.miny = cursor.Read<float>();
-            bbox.maxx = cursor.Read<float>();
-            bbox.maxy = cursor.Read<float>();
-            return true;
-        }
+			// Now set the bounding box
+			bbox.minx = cursor.Read<float>();
+			bbox.miny = cursor.Read<float>();
+			bbox.maxx = cursor.Read<float>();
+			bbox.maxy = cursor.Read<float>();
+			return true;
+		}
 
-        if (header_type == GeometryType::POINT) {
-            cursor.Skip(4); // skip padding
+		if (header_type == GeometryType::POINT) {
+			cursor.Skip(4); // skip padding
 
-            // Read the point
-            auto type = cursor.Read<SerializedGeometryType>();
-            D_ASSERT(type == SerializedGeometryType::POINT);
-            (void)type;
+			// Read the point
+			auto type = cursor.Read<SerializedGeometryType>();
+			D_ASSERT(type == SerializedGeometryType::POINT);
+			(void)type;
 
-            auto count = cursor.Read<uint32_t>();
-            if (count == 0) {
-                // If the point is empty, there is no bounding box
-                return false;
-            }
+			auto count = cursor.Read<uint32_t>();
+			if (count == 0) {
+				// If the point is empty, there is no bounding box
+				return false;
+			}
 
-            auto x = cursor.Read<double>();
-            auto y = cursor.Read<double>();
-            bbox.minx = x;
-            bbox.miny = y;
-            bbox.maxx = x;
-            bbox.maxy = y;
-            return true;
-        }
-        return false;
-    }
+			auto x = cursor.Read<double>();
+			auto y = cursor.Read<double>();
+			bbox.minx = x;
+			bbox.miny = y;
+			bbox.maxx = x;
+			bbox.maxy = y;
+			return true;
+		}
+		return false;
+	}
 };
 
 static_assert(sizeof(geometry_t) == sizeof(string_t), "geometry_t should be the same size as string_t");

--- a/spatial/include/spatial/core/geometry/vertex.hpp
+++ b/spatial/include/spatial/core/geometry/vertex.hpp
@@ -6,52 +6,50 @@ namespace spatial {
 
 namespace core {
 
-enum class VertexType : uint8_t {
-    XY, XYZ, XYM, XYZM
-};
+enum class VertexType : uint8_t { XY, XYZ, XYM, XYZM };
 
 struct VertexXY {
-    static const constexpr VertexType TYPE = VertexType::XY;
-    static const constexpr bool IS_VERTEX = true;
-    static const constexpr bool HAS_Z = false;
-    static const constexpr bool HAS_M = false;
+	static const constexpr VertexType TYPE = VertexType::XY;
+	static const constexpr bool IS_VERTEX = true;
+	static const constexpr bool HAS_Z = false;
+	static const constexpr bool HAS_M = false;
 
-    double x;
-    double y;
+	double x;
+	double y;
 };
 
 struct VertexXYZ {
-    static const constexpr VertexType TYPE = VertexType::XYZ;
-    static const constexpr bool IS_VERTEX = true;
-    static const constexpr bool HAS_Z = true;
-    static const constexpr bool HAS_M = false;
+	static const constexpr VertexType TYPE = VertexType::XYZ;
+	static const constexpr bool IS_VERTEX = true;
+	static const constexpr bool HAS_Z = true;
+	static const constexpr bool HAS_M = false;
 
-    double x;
-    double y;
-    double z;
+	double x;
+	double y;
+	double z;
 };
 
 struct VertexXYM {
-    static const constexpr VertexType TYPE = VertexType::XYM;
-    static const constexpr bool IS_VERTEX = true;
-    static const constexpr bool HAS_Z = false;
-    static const constexpr bool HAS_M = true;
+	static const constexpr VertexType TYPE = VertexType::XYM;
+	static const constexpr bool IS_VERTEX = true;
+	static const constexpr bool HAS_Z = false;
+	static const constexpr bool HAS_M = true;
 
-    double x;
-    double y;
-    double m;
+	double x;
+	double y;
+	double m;
 };
 
 struct VertexXYZM {
-    static const constexpr VertexType TYPE = VertexType::XYZM;
-    static const constexpr bool IS_VERTEX = true;
-    static const constexpr bool HAS_Z = true;
-    static const constexpr bool HAS_M = true;
+	static const constexpr VertexType TYPE = VertexType::XYZM;
+	static const constexpr bool IS_VERTEX = true;
+	static const constexpr bool HAS_Z = true;
+	static const constexpr bool HAS_M = true;
 
-    double x;
-    double y;
-    double z;
-    double m;
+	double x;
+	double y;
+	double z;
+	double m;
 };
 
 } // namespace core

--- a/spatial/include/spatial/core/geometry/wkb_reader.hpp
+++ b/spatial/include/spatial/core/geometry/wkb_reader.hpp
@@ -22,6 +22,7 @@ private:
 	uint32_t ReadInt(Cursor &cursor, bool little_endian);
 	double ReadDouble(Cursor &cursor, bool little_endian);
 	WKBType ReadType(Cursor &cursor, bool little_endian);
+	void ReadVertices(Cursor &cursor, bool little_endian, bool has_z, bool has_m, SinglePartGeometry &geometry);
 
 	// Geometries
 	Point ReadPoint(Cursor &cursor, bool little_endian, bool has_z, bool has_m);

--- a/spatial/include/spatial/core/geometry/wkt_reader.hpp
+++ b/spatial/include/spatial/core/geometry/wkt_reader.hpp
@@ -24,7 +24,7 @@ private:
 	bool MatchCI(const char *str);
 	void Expect(char c);
 	void ParseVertex(vector<double> &coords);
-    pair<uint32_t, vector<double>> ParseVertices();
+	pair<uint32_t, vector<double>> ParseVertices();
 	Point ParsePoint();
 	LineString ParseLineString();
 	Polygon ParsePolygon();

--- a/spatial/include/spatial/gdal/file_handler.hpp
+++ b/spatial/include/spatial/gdal/file_handler.hpp
@@ -17,7 +17,7 @@ public:
 	explicit GDALClientContextState(ClientContext &context);
 	~GDALClientContextState() override;
 	void QueryEnd() override;
-	const string &GetPrefix() const;
+	string GetPrefix(const string &value) const;
 	static GDALClientContextState &GetOrCreate(ClientContext &context);
 };
 

--- a/spatial/include/spatial/geos/functions/common.hpp
+++ b/spatial/include/spatial/geos/functions/common.hpp
@@ -9,7 +9,7 @@ namespace geos {
 struct GEOSFunctionLocalState : FunctionLocalState {
 public:
 	GeosContextWrapper ctx;
-    ArenaAllocator arena;
+	ArenaAllocator arena;
 
 public:
 	explicit GEOSFunctionLocalState(ClientContext &context);

--- a/spatial/src/spatial/core/functions/aggregate/st_envelope_agg.cpp
+++ b/spatial/src/spatial/core/functions/aggregate/st_envelope_agg.cpp
@@ -75,8 +75,8 @@ struct EnvelopeAggFunction {
 			finalize_data.ReturnNull();
 		} else {
 			auto &arena = finalize_data.input.allocator;
-            auto box = Polygon::FromBox(arena, state.xmin, state.ymin, state.xmax, state.ymax);
-            target = Geometry(box).Serialize(finalize_data.result);
+			auto box = Polygon::FromBox(arena, state.xmin, state.ymin, state.xmax, state.ymax);
+			target = Geometry(box).Serialize(finalize_data.result);
 		}
 	}
 
@@ -103,7 +103,8 @@ void CoreAggregateFunctions::RegisterStEnvelopeAgg(DatabaseInstance &db) {
 
 	AggregateFunctionSet st_envelope_agg("ST_Envelope_Agg");
 	st_envelope_agg.AddFunction(
-	    AggregateFunction::UnaryAggregate<EnvelopeAggState, geometry_t, geometry_t, EnvelopeAggFunction>(GeoTypes::GEOMETRY(), GeoTypes::GEOMETRY()));
+	    AggregateFunction::UnaryAggregate<EnvelopeAggState, geometry_t, geometry_t, EnvelopeAggFunction>(
+	        GeoTypes::GEOMETRY(), GeoTypes::GEOMETRY()));
 
 	ExtensionUtil::RegisterFunction(db, st_envelope_agg);
 	DocUtil::AddDocumentation(db, "ST_Envelope_Agg", DOC_DESCRIPTION, DOC_EXAMPLE, DOC_TAGS);

--- a/spatial/src/spatial/core/functions/cast/geometry_cast.cpp
+++ b/spatial/src/spatial/core/functions/cast/geometry_cast.cpp
@@ -19,10 +19,10 @@ static bool Point2DToGeometryCast(Vector &source, Vector &result, idx_t count, C
 	using GEOMETRY_TYPE = PrimitiveType<geometry_t>;
 
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(parameters);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 
 	GenericExecutor::ExecuteUnary<POINT_TYPE, GEOMETRY_TYPE>(source, result, count, [&](POINT_TYPE &point) {
-        Point geom(arena, point.a_val, point.b_val);
+		Point geom(arena, point.a_val, point.b_val);
 		return Geometry(geom).Serialize(result);
 	});
 	return true;
@@ -36,7 +36,7 @@ static bool GeometryToPoint2DCast(Vector &source, Vector &result, idx_t count, C
 	using GEOMETRY_TYPE = PrimitiveType<geometry_t>;
 
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(parameters);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 
 	GenericExecutor::ExecuteUnary<GEOMETRY_TYPE, POINT_TYPE>(source, result, count, [&](GEOMETRY_TYPE &geometry) {
 		auto geom = Geometry::Deserialize(arena, geometry.val);
@@ -45,7 +45,7 @@ static bool GeometryToPoint2DCast(Vector &source, Vector &result, idx_t count, C
 		}
 		auto &point = geom.As<Point>();
 		if (point.IsEmpty()) {
-            // TODO: Maybe make this return NULL instead
+			// TODO: Maybe make this return NULL instead
 			throw ConversionException("Cannot cast empty point GEOMETRY to POINT_2D");
 		}
 		auto vertex = point.Get(0);
@@ -68,11 +68,11 @@ static bool LineString2DToGeometryCast(Vector &source, Vector &result, idx_t cou
 	auto y_data = FlatVector::GetData<double>(*coord_vec_children[1]);
 
 	UnaryExecutor::Execute<list_entry_t, geometry_t>(source, result, count, [&](list_entry_t &line) {
-        LineString geom(arena, line.length, false, false);
+		LineString geom(arena, line.length, false, false);
 		for (idx_t i = 0; i < line.length; i++) {
 			auto x = x_data[line.offset + i];
 			auto y = y_data[line.offset + i];
-			geom.SetExact(i, VertexXY { x, y });
+			geom.SetExact(i, VertexXY {x, y});
 		}
 		return Geometry(geom).Serialize(result);
 	});
@@ -84,7 +84,7 @@ static bool LineString2DToGeometryCast(Vector &source, Vector &result, idx_t cou
 //------------------------------------------------------------------------------
 static bool GeometryToLineString2DCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(parameters);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 
 	auto &coord_vec = ListVector::GetEntry(result);
 	auto &coord_vec_children = StructVector::GetEntries(coord_vec);
@@ -105,7 +105,7 @@ static bool GeometryToLineString2DCast(Vector &source, Vector &result, idx_t cou
 		ListVector::Reserve(result, total_coords);
 
 		for (idx_t i = 0; i < line_size; i++) {
-            auto vertex = line.Get(i);
+			auto vertex = line.Get(i);
 			x_data[entry.offset + i] = vertex.x;
 			y_data[entry.offset + i] = vertex.y;
 		}
@@ -120,7 +120,7 @@ static bool GeometryToLineString2DCast(Vector &source, Vector &result, idx_t cou
 //------------------------------------------------------------------------------
 static bool Polygon2DToGeometryCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(parameters);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 
 	auto &ring_vec = ListVector::GetEntry(source);
 	auto ring_entries = ListVector::GetData(ring_vec);
@@ -139,7 +139,7 @@ static bool Polygon2DToGeometryCast(Vector &source, Vector &result, idx_t count,
 			for (idx_t j = 0; j < ring.length; j++) {
 				auto x = x_data[ring.offset + j];
 				auto y = y_data[ring.offset + j];
-				ring_array.SetExact(j, VertexXY { x, y });
+				ring_array.SetExact(j, VertexXY {x, y});
 			}
 		}
 		return Geometry(geom).Serialize(result);
@@ -152,7 +152,7 @@ static bool Polygon2DToGeometryCast(Vector &source, Vector &result, idx_t count,
 //------------------------------------------------------------------------------
 static bool GeometryToPolygon2DCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(parameters);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 
 	auto &ring_vec = ListVector::GetEntry(result);
 
@@ -216,8 +216,8 @@ static bool Box2DToGeometryCast(Vector &source, Vector &result, idx_t count, Cas
 		auto miny = box.b_val;
 		auto maxx = box.c_val;
 		auto maxy = box.d_val;
-        auto polygon = Polygon::FromBox(arena, minx, miny, maxx, maxy);
-        return Geometry(polygon).Serialize(result);
+		auto polygon = Polygon::FromBox(arena, minx, miny, maxx, maxy);
+		return Geometry(polygon).Serialize(result);
 	});
 	return true;
 }

--- a/spatial/src/spatial/core/functions/cast/wkb_cast.cpp
+++ b/spatial/src/spatial/core/functions/cast/wkb_cast.cpp
@@ -18,8 +18,8 @@ namespace core {
 //------------------------------------------------------------------------------
 static bool WKBToGeometryCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 
-    auto &lstate = GeometryFunctionLocalState::ResetAndGet(parameters);
-    WKBReader reader(lstate.arena);
+	auto &lstate = GeometryFunctionLocalState::ResetAndGet(parameters);
+	WKBReader reader(lstate.arena);
 
 	bool success = true;
 	UnaryExecutor::ExecuteWithNulls<string_t, geometry_t>(

--- a/spatial/src/spatial/core/functions/common.cpp
+++ b/spatial/src/spatial/core/functions/common.cpp
@@ -5,8 +5,7 @@ namespace spatial {
 
 namespace core {
 
-GeometryFunctionLocalState::GeometryFunctionLocalState(ClientContext &context)
-    : arena(BufferAllocator::Get(context)) {
+GeometryFunctionLocalState::GeometryFunctionLocalState(ClientContext &context) : arena(BufferAllocator::Get(context)) {
 }
 
 unique_ptr<FunctionLocalState>

--- a/spatial/src/spatial/core/functions/scalar/st_asgeojson.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_asgeojson.cpp
@@ -273,14 +273,14 @@ static Point PointFromGeoJSON(yyjson_val *coord_array, ArenaAllocator &arena, co
 			                            raw.GetString());
 		}
 		auto z = yyjson_get_num(z_val);
-		return Point::FromVertex(arena, VertexXYZ{ x, y, z});
+		return Point::FromVertex(arena, VertexXYZ {x, y, z});
 	} else {
-		return Point::FromVertex(arena, VertexXY{ x, y });
+		return Point::FromVertex(arena, VertexXY {x, y});
 	}
 }
 
 static LineString VerticesFromGeoJSON(yyjson_val *coord_array, ArenaAllocator &arena, const string_t &raw,
-                                       bool &has_z) {
+                                      bool &has_z) {
 	auto len = yyjson_arr_size(coord_array);
 	if (len == 0) {
 		// Empty
@@ -335,9 +335,9 @@ static LineString VerticesFromGeoJSON(yyjson_val *coord_array, ArenaAllocator &a
 				z = yyjson_get_num(z_val);
 			}
 			if (has_any_z) {
-				vertices.SetExact(idx, VertexXYZ { x, y, z });
+				vertices.SetExact(idx, VertexXYZ {x, y, z});
 			} else {
-				vertices.SetExact(idx, VertexXY { x, y });
+				vertices.SetExact(idx, VertexXY {x, y});
 			}
 		}
 		return vertices;
@@ -397,8 +397,8 @@ static MultiPoint MultiPointFromGeoJSON(yyjson_val *coord_array, ArenaAllocator 
 	}
 }
 
-static MultiLineString MultiLineStringFromGeoJSON(yyjson_val *coord_array, ArenaAllocator &arena,
-                                                  const string_t &raw, bool &has_z) {
+static MultiLineString MultiLineStringFromGeoJSON(yyjson_val *coord_array, ArenaAllocator &arena, const string_t &raw,
+                                                  bool &has_z) {
 	auto num_linestrings = yyjson_arr_size(coord_array);
 	if (num_linestrings == 0) {
 		// Empty
@@ -589,9 +589,9 @@ void CoreScalarFunctions::RegisterStAsGeoJSON(DatabaseInstance &db) {
 	                                        GeoJSONFragmentToGeometryFunction, nullptr, nullptr, nullptr,
 	                                        GeometryFunctionLocalState::Init));
 
-    from_geojson.AddFunction(ScalarFunction({LogicalType::JSON()}, GeoTypes::GEOMETRY(),
-                                            GeoJSONFragmentToGeometryFunction, nullptr, nullptr, nullptr,
-                                            GeometryFunctionLocalState::Init));
+	from_geojson.AddFunction(ScalarFunction({LogicalType::JSON()}, GeoTypes::GEOMETRY(),
+	                                        GeoJSONFragmentToGeometryFunction, nullptr, nullptr, nullptr,
+	                                        GeometryFunctionLocalState::Init));
 
 	ExtensionUtil::RegisterFunction(db, from_geojson);
 	DocUtil::AddDocumentation(db, "ST_GeomFromGeoJSON", FROM_DOC_DESCRIPTION, FROM_DOC_EXAMPLE, DOC_TAGS);

--- a/spatial/src/spatial/core/functions/scalar/st_collect.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_collect.cpp
@@ -53,7 +53,7 @@ static void CollectFunction(DataChunk &args, ExpressionState &state, Vector &res
 
 		if (geometries.empty()) {
 			GeometryCollection empty(has_z, has_m);
-            return Geometry(empty).Serialize(result);
+			return Geometry(empty).Serialize(result);
 		}
 
 		bool all_points = true;
@@ -79,7 +79,7 @@ static void CollectFunction(DataChunk &args, ExpressionState &state, Vector &res
 			for (idx_t i = 0; i < geometries.size(); i++) {
 				collection[i] = geometries[i].SetVertexType(arena, has_z, has_m).As<Point>();
 			}
-            return Geometry(collection).Serialize(result);
+			return Geometry(collection).Serialize(result);
 		} else if (all_lines) {
 			MultiLineString collection(arena, geometries.size(), has_z, has_m);
 			for (idx_t i = 0; i < geometries.size(); i++) {

--- a/spatial/src/spatial/core/functions/scalar/st_collectionextract.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_collectionextract.cpp
@@ -93,7 +93,7 @@ static void CollectPolygons(Geometry &geom, vector<Polygon> &polys) {
 // Collection extract with a specific dimension
 static void CollectionExtractTypeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 	auto count = args.size();
 	auto &input = args.data[0];
 	auto &dim = args.data[1];
@@ -117,19 +117,20 @@ static void CollectionExtractTypeFunction(DataChunk &args, ExpressionState &stat
 					    for (uint32_t i = 0; i < size; i++) {
 						    mpoint[i] = points[i];
 					    }
-                        return Geometry(mpoint).Serialize(result);
+					    return Geometry(mpoint).Serialize(result);
 				    }
 				    // otherwise, we return an empty multipoint
 				    MultiPoint empty(props.HasZ(), props.HasM());
-                    return Geometry(empty).Serialize(result);
+				    return Geometry(empty).Serialize(result);
 			    } else {
 				    // otherwise if its not a collection, we return an empty point
 				    Point empty(props.HasZ(), props.HasM());
-                    return Geometry(empty).Serialize(result);
+				    return Geometry(empty).Serialize(result);
 			    }
 		    }
 		    case 2: {
-			    if (geometry.GetType() == GeometryType::MULTILINESTRING || geometry.GetType() == GeometryType::LINESTRING) {
+			    if (geometry.GetType() == GeometryType::MULTILINESTRING ||
+			        geometry.GetType() == GeometryType::LINESTRING) {
 				    return input;
 			    } else if (geometry.IsCollection()) {
 				    // if it is a geometry collection, we need to collect all lines
@@ -142,15 +143,15 @@ static void CollectionExtractTypeFunction(DataChunk &args, ExpressionState &stat
 					    for (uint32_t i = 0; i < size; i++) {
 						    mline[i] = lines[i];
 					    }
-                        return Geometry(mline).Serialize(result);
+					    return Geometry(mline).Serialize(result);
 				    }
 				    // otherwise, we return an empty multilinestring
 				    MultiLineString empty(props.HasZ(), props.HasM());
-                    return Geometry(empty).Serialize(result);
+				    return Geometry(empty).Serialize(result);
 			    } else {
 				    // otherwise if its not a collection, we return an empty linestring
 				    LineString empty(props.HasZ(), props.HasM());
-                    return Geometry(empty).Serialize(result);
+				    return Geometry(empty).Serialize(result);
 			    }
 		    }
 		    case 3: {
@@ -167,15 +168,15 @@ static void CollectionExtractTypeFunction(DataChunk &args, ExpressionState &stat
 					    for (uint32_t i = 0; i < size; i++) {
 						    mpoly[i] = polys[i];
 					    }
-                        return Geometry(mpoly).Serialize(result);
+					    return Geometry(mpoly).Serialize(result);
 				    }
 				    // otherwise, we return an empty multipolygon
 				    MultiPolygon empty(props.HasZ(), props.HasM());
-                    return Geometry(empty).Serialize(result);
+				    return Geometry(empty).Serialize(result);
 			    } else {
 				    // otherwise if its not a collection, we return an empty polygon
 				    Polygon empty(props.HasZ(), props.HasM());
-                    return Geometry(empty).Serialize(result);
+				    return Geometry(empty).Serialize(result);
 			    }
 		    }
 		    default:
@@ -188,7 +189,7 @@ static void CollectionExtractTypeFunction(DataChunk &args, ExpressionState &stat
 // Note: We're being smart here and reusing the memory from the input geometry
 static void CollectionExtractAutoFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 
 	auto count = args.size();
 	auto &input = args.data[0];
@@ -216,7 +217,7 @@ static void CollectionExtractAutoFunction(DataChunk &args, ExpressionState &stat
 				for (uint32_t i = 0; i < size; i++) {
 					mpoint[i] = points[i];
 				}
-                return Geometry(mpoint).Serialize(result);
+				return Geometry(mpoint).Serialize(result);
 			}
 			// LineString case
 			case 1: {
@@ -238,7 +239,7 @@ static void CollectionExtractAutoFunction(DataChunk &args, ExpressionState &stat
 				for (uint32_t i = 0; i < size; i++) {
 					mpoly[i] = polys[i];
 				}
-                return Geometry(mpoly).Serialize(result);
+				return Geometry(mpoly).Serialize(result);
 			}
 			default: {
 				throw InternalException("Invalid dimension in collection extract");

--- a/spatial/src/spatial/core/functions/scalar/st_dump.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_dump.cpp
@@ -14,7 +14,7 @@ namespace core {
 
 static void DumpFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 	auto count = args.size();
 
 	auto &geom_vec = args.data[0];

--- a/spatial/src/spatial/core/functions/scalar/st_endpoint.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_endpoint.cpp
@@ -79,7 +79,7 @@ static void GeometryEndPointFunction(DataChunk &args, ExpressionState &state, Ve
 			    return geometry_t {};
 		    }
 
-            auto point = Point::FromReference(line, point_count - 1);
+		    auto point = Point::FromReference(line, point_count - 1);
 		    return Geometry(point).Serialize(result);
 	    });
 }

--- a/spatial/src/spatial/core/functions/scalar/st_exteriorring.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_exteriorring.cpp
@@ -92,7 +92,7 @@ static void PolygonExteriorRingFunction(DataChunk &args, ExpressionState &state,
 //------------------------------------------------------------------------------
 static void GeometryExteriorRingFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 	auto &input = args.data[0];
 	auto count = args.size();
 
@@ -105,12 +105,12 @@ static void GeometryExteriorRingFunction(DataChunk &args, ExpressionState &state
 
 		    auto polygon = Geometry::Deserialize(arena, input).As<Polygon>();
 		    if (polygon.IsEmpty()) {
-                LineString empty(polygon.GetProperties().HasZ(), polygon.GetProperties().HasM());
-                return Geometry(empty).Serialize(result);
+			    LineString empty(polygon.GetProperties().HasZ(), polygon.GetProperties().HasM());
+			    return Geometry(empty).Serialize(result);
 		    }
 
-            auto &shell = polygon[0];
-            return Geometry(shell).Serialize(result);
+		    auto &shell = polygon[0];
+		    return Geometry(shell).Serialize(result);
 	    });
 }
 

--- a/spatial/src/spatial/core/functions/scalar/st_flipcoordinates.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_flipcoordinates.cpp
@@ -154,8 +154,6 @@ static void BoxFlipCoordinatesFunction(DataChunk &args, ExpressionState &state, 
 // GEOMETRY
 //------------------------------------------------------------------------------
 
-
-
 static void GeometryFlipCoordinatesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
@@ -163,21 +161,21 @@ static void GeometryFlipCoordinatesFunction(DataChunk &args, ExpressionState &st
 	auto input = args.data[0];
 	auto count = args.size();
 
-    struct FlipOp {
-        static void Apply(SinglePartGeometry &geom, ArenaAllocator &arena) {
-            geom.MakeMutable(arena);
-            for (idx_t i = 0; i < geom.Count(); i++) {
-                auto vertex = geom.Get(i);
-                std::swap(vertex.x, vertex.y);
-                geom.Set(i, vertex);
-            }
-        }
-        static void Apply(MultiPartGeometry &geom, ArenaAllocator &arena) {
-            for (auto &part : geom) {
-                part.Visit<FlipOp>(arena);
-            }
-        }
-    };
+	struct FlipOp {
+		static void Apply(SinglePartGeometry &geom, ArenaAllocator &arena) {
+			geom.MakeMutable(arena);
+			for (idx_t i = 0; i < geom.Count(); i++) {
+				auto vertex = geom.Get(i);
+				std::swap(vertex.x, vertex.y);
+				geom.Set(i, vertex);
+			}
+		}
+		static void Apply(MultiPartGeometry &geom, ArenaAllocator &arena) {
+			for (auto &part : geom) {
+				part.Visit<FlipOp>(arena);
+			}
+		}
+	};
 
 	UnaryExecutor::Execute<geometry_t, geometry_t>(input, result, count, [&](geometry_t input) {
 		auto geom = Geometry::Deserialize(lstate.arena, input);

--- a/spatial/src/spatial/core/functions/scalar/st_force.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_force.cpp
@@ -26,20 +26,20 @@ static void GeometryFunction(DataChunk &args, ExpressionState &state, Vector &re
 		TernaryExecutor::Execute<geometry_t, double, double, geometry_t>(
 		    input, z_values, m_values, result, count, [&](const geometry_t &blob, double default_z, double default_m) {
 			    return Geometry::Deserialize(arena, blob)
-                    .SetVertexType(arena, HAS_Z, HAS_M, default_z, default_m)
-                    .Serialize(result);
+			        .SetVertexType(arena, HAS_Z, HAS_M, default_z, default_m)
+			        .Serialize(result);
 		    });
 
 	} else if (HAS_Z || HAS_M) {
 		auto &z_values = args.data[1];
 		BinaryExecutor::Execute<geometry_t, double, geometry_t>(
 		    input, z_values, result, count, [&](const geometry_t &blob, double default_value) {
-                auto def_z = HAS_Z ? default_value : 0;
-                auto def_m = HAS_M ? default_value : 0;
+			    auto def_z = HAS_Z ? default_value : 0;
+			    auto def_m = HAS_M ? default_value : 0;
 
 			    return Geometry::Deserialize(arena, blob)
-                    .SetVertexType(arena, HAS_Z, HAS_M, def_z, def_m)
-                    .Serialize(result);
+			        .SetVertexType(arena, HAS_Z, HAS_M, def_z, def_m)
+			        .Serialize(result);
 		    });
 	} else {
 		UnaryExecutor::Execute<geometry_t, geometry_t>(input, result, count, [&](const geometry_t &blob) {

--- a/spatial/src/spatial/core/functions/scalar/st_geomfromtext.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_geomfromtext.cpp
@@ -38,22 +38,22 @@ static void GeometryFromWKTFunction(DataChunk &args, ExpressionState &state, Vec
 	const auto &info = func_expr.bind_info->Cast<GeometryFromWKTBindData>();
 
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 
 	WKTReader reader(arena);
-	UnaryExecutor::ExecuteWithNulls<string_t, geometry_t>(
-	    input, result, count, [&](string_t &wkt, ValidityMask &mask, idx_t idx) {
-		    try {
-			    auto geom = reader.Parse(wkt);
-			    return geom.Serialize(result);
-		    } catch (InvalidInputException &error) {
-			    if (!info.ignore_invalid) {
-				    throw;
-			    }
-			    mask.SetInvalid(idx);
-			    return geometry_t {};
-		    }
-	    });
+	UnaryExecutor::ExecuteWithNulls<string_t, geometry_t>(input, result, count,
+	                                                      [&](string_t &wkt, ValidityMask &mask, idx_t idx) {
+		                                                      try {
+			                                                      auto geom = reader.Parse(wkt);
+			                                                      return geom.Serialize(result);
+		                                                      } catch (InvalidInputException &error) {
+			                                                      if (!info.ignore_invalid) {
+				                                                      throw;
+			                                                      }
+			                                                      mask.SetInvalid(idx);
+			                                                      return geometry_t {};
+		                                                      }
+	                                                      });
 }
 
 static unique_ptr<FunctionData> GeometryFromWKTBind(ClientContext &context, ScalarFunction &bound_function,

--- a/spatial/src/spatial/core/functions/scalar/st_geomfromwkb.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_geomfromwkb.cpp
@@ -268,14 +268,13 @@ static void Polygon2DFromWKBFunction(DataChunk &args, ExpressionState &state, Ve
 //------------------------------------------------------------------------------
 static void GeometryFromWKBFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 	auto &input = args.data[0];
 	auto count = args.size();
 
 	WKBReader reader(arena);
-	UnaryExecutor::Execute<string_t, geometry_t>(input, result, count, [&](string_t input) {
-		return reader.Deserialize(input).Serialize(result);
-	});
+	UnaryExecutor::Execute<string_t, geometry_t>(
+	    input, result, count, [&](string_t input) { return reader.Deserialize(input).Serialize(result); });
 }
 
 //------------------------------------------------------------------------------

--- a/spatial/src/spatial/core/functions/scalar/st_intersects_extent.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_intersects_extent.cpp
@@ -23,8 +23,7 @@ static void IntersectsExtentFunction(DataChunk &args, ExpressionState &state, Ve
 	    left, right, result, count, [&](geometry_t left, geometry_t right) {
 		    BoundingBox left_bbox;
 		    BoundingBox right_bbox;
-		    if (left.TryGetCachedBounds(left_bbox) &&
-		        right.TryGetCachedBounds(right_bbox)) {
+		    if (left.TryGetCachedBounds(left_bbox) && right.TryGetCachedBounds(right_bbox)) {
 			    return left_bbox.Intersects(right_bbox);
 		    }
 		    return false;

--- a/spatial/src/spatial/core/functions/scalar/st_isempty.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_isempty.cpp
@@ -52,9 +52,8 @@ static void GeometryIsEmptyFunction(DataChunk &args, ExpressionState &state, Vec
 	auto &input = args.data[0];
 	auto count = args.size();
 
-	UnaryExecutor::Execute<geometry_t, bool>(input, result, count, [&](geometry_t input) {
-		return Geometry::Deserialize(lstate.arena, input).IsEmpty();
-	});
+	UnaryExecutor::Execute<geometry_t, bool>(
+	    input, result, count, [&](geometry_t input) { return Geometry::Deserialize(lstate.arena, input).IsEmpty(); });
 
 	if (count == 1) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);

--- a/spatial/src/spatial/core/functions/scalar/st_length.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_length.cpp
@@ -49,40 +49,39 @@ static void LineLengthFunction(DataChunk &args, ExpressionState &state, Vector &
 static void GeometryLengthFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 
 	auto &input = args.data[0];
 	auto count = args.size();
 
-    struct op {
-        static double Apply(const LineString &line) {
-            return line.Length();
-        }
+	struct op {
+		static double Apply(const LineString &line) {
+			return line.Length();
+		}
 
-        static double Apply(const MultiLineString &mline) {
-            double sum = 0.0;
-            for (const auto &line : mline) {
-                sum += line.Length();
-            }
-            return sum;
-        }
+		static double Apply(const MultiLineString &mline) {
+			double sum = 0.0;
+			for (const auto &line : mline) {
+				sum += line.Length();
+			}
+			return sum;
+		}
 
-        static double Apply(const GeometryCollection &collection) {
-            double sum = 0.0;
-            for (const auto &geom : collection) {
-                sum += geom.Visit<op>();
-            }
-            return sum;
-        }
+		static double Apply(const GeometryCollection &collection) {
+			double sum = 0.0;
+			for (const auto &geom : collection) {
+				sum += geom.Visit<op>();
+			}
+			return sum;
+		}
 
-        static double Apply(const BaseGeometry &) {
-            return 0.0;
-        }
-    };
+		static double Apply(const BaseGeometry &) {
+			return 0.0;
+		}
+	};
 
-	UnaryExecutor::Execute<geometry_t, double>(input, result, count, [&](geometry_t input) {
-		return Geometry::Deserialize(arena, input).Visit<op>();
-	});
+	UnaryExecutor::Execute<geometry_t, double>(
+	    input, result, count, [&](geometry_t input) { return Geometry::Deserialize(arena, input).Visit<op>(); });
 
 	if (count == 1) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);

--- a/spatial/src/spatial/core/functions/scalar/st_makeenvelope.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_makeenvelope.cpp
@@ -26,8 +26,8 @@ static void MakeEnvelopeFunction(DataChunk &args, ExpressionState &state, Vector
 	GenericExecutor::ExecuteQuaternary<DOUBLE_TYPE, DOUBLE_TYPE, DOUBLE_TYPE, DOUBLE_TYPE, GEOMETRY_TYPE>(
 	    min_x_vec, min_y_vec, max_x_vec, max_y_vec, result, count,
 	    [&](DOUBLE_TYPE x_min, DOUBLE_TYPE y_min, DOUBLE_TYPE x_max, DOUBLE_TYPE y_max) {
-            auto box = Polygon::FromBox(lstate.arena, x_min.val, y_min.val, x_max.val, y_max.val);
-            return Geometry(box).Serialize(result);
+		    auto box = Polygon::FromBox(lstate.arena, x_min.val, y_min.val, x_max.val, y_max.val);
+		    return Geometry(box).Serialize(result);
 	    });
 }
 

--- a/spatial/src/spatial/core/functions/scalar/st_makeline.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_makeline.cpp
@@ -14,7 +14,7 @@ namespace core {
 
 static void MakeLineListFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 
 	auto count = args.size();
 	auto &child_vec = ListVector::GetEntry(args.data[0]);
@@ -66,7 +66,7 @@ static void MakeLineListFunction(DataChunk &args, ExpressionState &state, Vector
 
 static void MakeLineBinaryFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 
 	auto count = args.size();
 
@@ -100,9 +100,9 @@ static void MakeLineBinaryFunction(DataChunk &args, ExpressionState &state, Vect
 		    point_left.SetVertexType(arena, has_z, has_m);
 		    point_right.SetVertexType(arena, has_z, has_m);
 
-            LineString line_geom(has_z, has_m);
-            line_geom.Append(arena, point_left);
-            line_geom.Append(arena, point_right);
+		    LineString line_geom(has_z, has_m);
+		    line_geom.Append(arena, point_left);
+		    line_geom.Append(arena, point_right);
 		    return Geometry(line_geom).Serialize(result);
 	    });
 }

--- a/spatial/src/spatial/core/functions/scalar/st_makepolygon.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_makepolygon.cpp
@@ -14,7 +14,7 @@ namespace core {
 
 static void MakePolygonFromRingsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 	auto count = args.size();
 
 	auto &child_vec = ListVector::GetEntry(args.data[1]);
@@ -93,7 +93,7 @@ static void MakePolygonFromRingsFunction(DataChunk &args, ExpressionState &state
 
 static void MakePolygonFromShellFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 
 	auto count = args.size();
 

--- a/spatial/src/spatial/core/functions/scalar/st_ngeometries.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_ngeometries.cpp
@@ -21,18 +21,18 @@ static void GeometryNGeometriesFunction(DataChunk &args, ExpressionState &state,
 	auto count = args.size();
 
 	UnaryExecutor::Execute<geometry_t, int32_t>(input, result, count, [&](geometry_t input) {
-        struct op {
-            static int32_t Apply(const CollectionGeometry &collection) {
-                return static_cast<int32_t>(collection.Count());
-            }
-            static int32_t Apply(const Polygon &geom) {
-                return geom.IsEmpty() ? 0 : 1;
-            }
-            static int32_t Apply(const SinglePartGeometry &geom) {
-                return geom.IsEmpty() ? 0 : 1;
-            }
-        };
-        return Geometry::Deserialize(ctx.arena, input).Visit<op>();
+		struct op {
+			static int32_t Apply(const CollectionGeometry &collection) {
+				return static_cast<int32_t>(collection.Count());
+			}
+			static int32_t Apply(const Polygon &geom) {
+				return geom.IsEmpty() ? 0 : 1;
+			}
+			static int32_t Apply(const SinglePartGeometry &geom) {
+				return geom.IsEmpty() ? 0 : 1;
+			}
+		};
+		return Geometry::Deserialize(ctx.arena, input).Visit<op>();
 	});
 }
 

--- a/spatial/src/spatial/core/functions/scalar/st_ninteriorrings.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_ninteriorrings.cpp
@@ -30,7 +30,7 @@ static void PolygonInteriorRingsFunction(DataChunk &args, ExpressionState &state
 //------------------------------------------------------------------------------
 static void GeometryInteriorRingsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 	auto &input = args.data[0];
 	auto count = args.size();
 

--- a/spatial/src/spatial/core/functions/scalar/st_npoints.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_npoints.cpp
@@ -70,27 +70,26 @@ static void BoxNumPointsFunction(DataChunk &args, ExpressionState &state, Vector
 
 static void GeometryNumPointsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 
 	auto &input = args.data[0];
 	auto count = args.size();
 
-    struct op {
-        static uint32_t Apply(const SinglePartGeometry &geom) {
-            return geom.Count();
-        }
-        static uint32_t Apply(const MultiPartGeometry &geom) {
-            uint32_t count = 0;
-            for (const auto &part : geom) {
-                count += part.Visit<op>();
-            }
-            return count;
-        }
-    };
+	struct op {
+		static uint32_t Apply(const SinglePartGeometry &geom) {
+			return geom.Count();
+		}
+		static uint32_t Apply(const MultiPartGeometry &geom) {
+			uint32_t count = 0;
+			for (const auto &part : geom) {
+				count += part.Visit<op>();
+			}
+			return count;
+		}
+	};
 
-	UnaryExecutor::Execute<geometry_t, uint32_t>(input, result, count, [&](geometry_t input) {
-		return Geometry::Deserialize(arena, input).Visit<op>();
-	});
+	UnaryExecutor::Execute<geometry_t, uint32_t>(
+	    input, result, count, [&](geometry_t input) { return Geometry::Deserialize(arena, input).Visit<op>(); });
 }
 
 //------------------------------------------------------------------------------

--- a/spatial/src/spatial/core/functions/scalar/st_perimeter.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_perimeter.cpp
@@ -73,44 +73,43 @@ static void Box2DPerimeterFunction(DataChunk &args, ExpressionState &state, Vect
 //------------------------------------------------------------------------------
 static void GeometryPerimeterFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = core::GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 
 	auto &input = args.data[0];
 	auto count = args.size();
 
-    struct op {
-        static double Apply(const Polygon &poly) {
-            double sum = 0;
-            for (const auto &ring : poly) {
-                sum += ring.Length();
-            }
-            return sum;
-        }
+	struct op {
+		static double Apply(const Polygon &poly) {
+			double sum = 0;
+			for (const auto &ring : poly) {
+				sum += ring.Length();
+			}
+			return sum;
+		}
 
-        static double Apply(const MultiPolygon &mline) {
-            double sum = 0.0;
-            for (const auto &poly : mline) {
-                sum += Apply(poly);
-            }
-            return sum;
-        }
+		static double Apply(const MultiPolygon &mline) {
+			double sum = 0.0;
+			for (const auto &poly : mline) {
+				sum += Apply(poly);
+			}
+			return sum;
+		}
 
-        static double Apply(const GeometryCollection &collection) {
-            double sum = 0.0;
-            for (const auto &geom : collection) {
-                sum += geom.Visit<op>();
-            }
-            return sum;
-        }
+		static double Apply(const GeometryCollection &collection) {
+			double sum = 0.0;
+			for (const auto &geom : collection) {
+				sum += geom.Visit<op>();
+			}
+			return sum;
+		}
 
-        static double Apply(const BaseGeometry &) {
-            return 0.0;
-        }
-    };
+		static double Apply(const BaseGeometry &) {
+			return 0.0;
+		}
+	};
 
-	UnaryExecutor::Execute<geometry_t, double>(input, result, count, [&](geometry_t input) {
-		return Geometry::Deserialize(arena, input).Visit<op>();
-	});
+	UnaryExecutor::Execute<geometry_t, double>(
+	    input, result, count, [&](geometry_t input) { return Geometry::Deserialize(arena, input).Visit<op>(); });
 
 	if (count == 1) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);

--- a/spatial/src/spatial/core/functions/scalar/st_point.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_point.cpp
@@ -101,13 +101,13 @@ static void Point4DFunction(DataChunk &args, ExpressionState &state, Vector &res
 //------------------------------------------------------------------------------
 static void PointFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 	auto &x = args.data[0];
 	auto &y = args.data[1];
 	auto count = args.size();
 
 	BinaryExecutor::Execute<double, double, geometry_t>(x, y, result, count, [&](double x, double y) {
-		return Geometry(Point::FromVertex(arena, VertexXY { x, y })).Serialize(result);
+		return Geometry(Point::FromVertex(arena, VertexXY {x, y})).Serialize(result);
 	});
 }
 

--- a/spatial/src/spatial/core/functions/scalar/st_pointn.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_pointn.cpp
@@ -67,7 +67,7 @@ static void LineStringPointNFunction(DataChunk &args, ExpressionState &state, Ve
 //------------------------------------------------------------------------------
 static void GeometryPointNFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 	auto &geom_vec = args.data[0];
 	auto &index_vec = args.data[1];
 
@@ -90,9 +90,9 @@ static void GeometryPointNFunction(DataChunk &args, ExpressionState &state, Vect
 
 		    auto actual_index = index < 0 ? point_count + index : index - 1;
 
-            auto point = Point::FromReference(line, actual_index);
+		    auto point = Point::FromReference(line, actual_index);
 
-            return Geometry(point).Serialize(result);
+		    return Geometry(point).Serialize(result);
 	    });
 }
 

--- a/spatial/src/spatial/core/functions/scalar/st_quadkey.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_quadkey.cpp
@@ -61,7 +61,7 @@ static void CoordinateQuadKeyFunction(DataChunk &args, ExpressionState &state, V
 //------------------------------------------------------------------------------
 static void GeometryQuadKeyFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 
 	auto &geom = args.data[0];
 	auto &level = args.data[1];

--- a/spatial/src/spatial/core/functions/scalar/st_startpoint.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_startpoint.cpp
@@ -78,7 +78,7 @@ static void GeometryStartPointFunction(DataChunk &args, ExpressionState &state, 
 			    return geometry_t {};
 		    }
 
-            auto point = Point::FromReference(line, 0);
+		    auto point = Point::FromReference(line, 0);
 
 		    return Geometry(point).Serialize(result);
 	    });

--- a/spatial/src/spatial/core/geometry/geometry.cpp
+++ b/spatial/src/spatial/core/geometry/geometry.cpp
@@ -9,283 +9,286 @@ namespace core {
 // Single Part Geometry
 //------------------------------------------------------------------------------
 void SinglePartGeometry::Reference(const SinglePartGeometry &other, uint32_t offset, uint32_t count) {
-    properties = other.properties;
-    data.vertex_data = other.data.vertex_data + offset * properties.VertexSize();
-    data_count = count;
-    is_readonly = true;
+	properties = other.properties;
+	data.vertex_data = other.data.vertex_data + offset * properties.VertexSize();
+	data_count = count;
+	is_readonly = true;
 }
 
 void SinglePartGeometry::ReferenceData(const_data_ptr_t data_ptr, uint32_t count, bool has_z, bool has_m) {
-    properties.SetZ(has_z);
-    properties.SetM(has_m);
-    data.vertex_data = const_cast<data_ptr_t>(data_ptr);
-    data_count = count;
-    is_readonly = true;
+	properties.SetZ(has_z);
+	properties.SetM(has_m);
+	data.vertex_data = const_cast<data_ptr_t>(data_ptr);
+	data_count = count;
+	is_readonly = true;
 }
 
-void SinglePartGeometry::Copy(ArenaAllocator& alloc, const SinglePartGeometry &other, uint32_t offset, uint32_t count) {
-    properties = other.properties;
-    data_count = count;
-    data.vertex_data = alloc.AllocateAligned(properties.VertexSize() * count);
-    memcpy(data.vertex_data, other.data.vertex_data + offset * properties.VertexSize(), properties.VertexSize() * count);
-    is_readonly = false;
+void SinglePartGeometry::Copy(ArenaAllocator &alloc, const SinglePartGeometry &other, uint32_t offset, uint32_t count) {
+	properties = other.properties;
+	data_count = count;
+	data.vertex_data = alloc.AllocateAligned(properties.VertexSize() * count);
+	memcpy(data.vertex_data, other.data.vertex_data + offset * properties.VertexSize(),
+	       properties.VertexSize() * count);
+	is_readonly = false;
 }
 
-void SinglePartGeometry::CopyData(ArenaAllocator& alloc, const_data_ptr_t data_ptr, uint32_t count, bool has_z, bool has_m) {
-    properties.SetZ(has_z);
-    properties.SetM(has_m);
-    data_count = count;
-    data.vertex_data = alloc.AllocateAligned(properties.VertexSize() * count);
-    memcpy(data.vertex_data, data_ptr, properties.VertexSize() * count);
-    is_readonly = false;
+void SinglePartGeometry::CopyData(ArenaAllocator &alloc, const_data_ptr_t data_ptr, uint32_t count, bool has_z,
+                                  bool has_m) {
+	properties.SetZ(has_z);
+	properties.SetM(has_m);
+	data_count = count;
+	data.vertex_data = alloc.AllocateAligned(properties.VertexSize() * count);
+	memcpy(data.vertex_data, data_ptr, properties.VertexSize() * count);
+	is_readonly = false;
 }
 
 void SinglePartGeometry::Resize(ArenaAllocator &alloc, uint32_t new_count) {
-    auto vertex_size = properties.VertexSize();
-    if (new_count == data_count) {
-        return;
-    }
-    if (data.vertex_data == nullptr) {
-        data.vertex_data = alloc.AllocateAligned(vertex_size * new_count);
-        data_count = new_count;
-        is_readonly = false;
-        memset(data.vertex_data, 0, vertex_size * new_count);
-        return;
-    }
+	auto vertex_size = properties.VertexSize();
+	if (new_count == data_count) {
+		return;
+	}
+	if (data.vertex_data == nullptr) {
+		data.vertex_data = alloc.AllocateAligned(vertex_size * new_count);
+		data_count = new_count;
+		is_readonly = false;
+		memset(data.vertex_data, 0, vertex_size * new_count);
+		return;
+	}
 
-    if (!IsReadOnly()) {
-        data.vertex_data = alloc.Reallocate(data.vertex_data, data_count * vertex_size, vertex_size * new_count);
-        data_count = new_count;
-    } else {
-        auto new_data = alloc.AllocateAligned(vertex_size * new_count);
-        memset(new_data, 0, vertex_size * new_count);
-        auto copy_count = std::min(data_count, new_count);
-        memcpy(new_data, data.vertex_data, vertex_size * copy_count);
-        data.vertex_data = new_data;
-        data_count = new_count;
-        is_readonly = false;
-    }
+	if (!IsReadOnly()) {
+		data.vertex_data = alloc.Reallocate(data.vertex_data, data_count * vertex_size, vertex_size * new_count);
+		data_count = new_count;
+	} else {
+		auto new_data = alloc.AllocateAligned(vertex_size * new_count);
+		memset(new_data, 0, vertex_size * new_count);
+		auto copy_count = std::min(data_count, new_count);
+		memcpy(new_data, data.vertex_data, vertex_size * copy_count);
+		data.vertex_data = new_data;
+		data_count = new_count;
+		is_readonly = false;
+	}
 }
 
-void SinglePartGeometry::Append(ArenaAllocator &alloc, const SinglePartGeometry& other) {
-    Append(alloc, &other, 1);
+void SinglePartGeometry::Append(ArenaAllocator &alloc, const SinglePartGeometry &other) {
+	Append(alloc, &other, 1);
 }
 
-void SinglePartGeometry::Append(ArenaAllocator &alloc, const SinglePartGeometry* others, uint32_t others_count) {
-    if (IsReadOnly()) {
-        MakeMutable(alloc);
-    }
+void SinglePartGeometry::Append(ArenaAllocator &alloc, const SinglePartGeometry *others, uint32_t others_count) {
+	if (IsReadOnly()) {
+		MakeMutable(alloc);
+	}
 
-    auto old_count = data_count;
-    auto new_count = old_count;
-    for (uint32_t i = 0; i < others_count; i++) {
-        new_count += others[i].Count();
-        D_ASSERT(properties.HasZ() == others[i].properties.HasZ());
-        D_ASSERT(properties.HasM() == others[i].properties.HasM());
-    }
-    Resize(alloc, new_count);
+	auto old_count = data_count;
+	auto new_count = old_count;
+	for (uint32_t i = 0; i < others_count; i++) {
+		new_count += others[i].Count();
+		D_ASSERT(properties.HasZ() == others[i].properties.HasZ());
+		D_ASSERT(properties.HasM() == others[i].properties.HasM());
+	}
+	Resize(alloc, new_count);
 
-    auto vertex_size = properties.VertexSize();
-    for(uint32_t i = 0; i < others_count; i++) {
-        auto other = others[i];
-        memcpy(data.vertex_data + old_count * vertex_size, other.data.vertex_data, vertex_size * other.data_count);
-        old_count += other.data_count;
-    }
-    data_count = new_count;
+	auto vertex_size = properties.VertexSize();
+	for (uint32_t i = 0; i < others_count; i++) {
+		auto other = others[i];
+		memcpy(data.vertex_data + old_count * vertex_size, other.data.vertex_data, vertex_size * other.data_count);
+		old_count += other.data_count;
+	}
+	data_count = new_count;
 }
 
-void SinglePartGeometry::SetVertexType(ArenaAllocator &alloc, bool has_z, bool has_m, double default_z, double default_m) {
-    if (properties.HasZ() == has_z && properties.HasM() == has_m) {
-        return;
-    }
-    if (IsReadOnly()) {
-        MakeMutable(alloc);
-    }
+void SinglePartGeometry::SetVertexType(ArenaAllocator &alloc, bool has_z, bool has_m, double default_z,
+                                       double default_m) {
+	if (properties.HasZ() == has_z && properties.HasM() == has_m) {
+		return;
+	}
+	if (IsReadOnly()) {
+		MakeMutable(alloc);
+	}
 
-    auto used_to_have_z = properties.HasZ();
-    auto used_to_have_m = properties.HasM();
-    auto old_vertex_size = properties.VertexSize();
+	auto used_to_have_z = properties.HasZ();
+	auto used_to_have_m = properties.HasM();
+	auto old_vertex_size = properties.VertexSize();
 
-    properties.SetZ(has_z);
-    properties.SetM(has_m);
+	properties.SetZ(has_z);
+	properties.SetM(has_m);
 
-    auto new_vertex_size = properties.VertexSize();
-    // Case 1: The new vertex size is larger than the old vertex size
-    if (new_vertex_size > old_vertex_size) {
-        data.vertex_data =
-                alloc.ReallocateAligned(data.vertex_data, data_count * old_vertex_size, data_count * new_vertex_size);
+	auto new_vertex_size = properties.VertexSize();
+	// Case 1: The new vertex size is larger than the old vertex size
+	if (new_vertex_size > old_vertex_size) {
+		data.vertex_data =
+		    alloc.ReallocateAligned(data.vertex_data, data_count * old_vertex_size, data_count * new_vertex_size);
 
-        // There are 5 cases here:
-        if (used_to_have_m && has_m && !used_to_have_z && has_z) {
-            // 1. We go from XYM to XYZM
-            // This is special, because we need to slide the M value to the end of each vertex
-            for (int64_t i = data_count - 1; i >= 0; i--) {
-                auto old_offset = i * old_vertex_size;
-                auto new_offset = i * new_vertex_size;
-                auto old_m_offset = old_offset + sizeof(double) * 2;
-                auto new_z_offset = new_offset + sizeof(double) * 2;
-                auto new_m_offset = new_offset + sizeof(double) * 3;
-                // Move the M value
-                memcpy(data.vertex_data + new_m_offset, data.vertex_data + old_m_offset, sizeof(double));
-                // Set the new Z value
-                memcpy(data.vertex_data + new_z_offset, &default_z, sizeof(double));
-                // Move the X and Y values
-                memcpy(data.vertex_data + new_offset, data.vertex_data + old_offset, sizeof(double) * 2);
-            }
-        } else if (!used_to_have_z && has_z && !used_to_have_m && has_m) {
-            // 2. We go from XY to XYZM
-            // This is special, because we need to add both the default Z and M values to the end of each vertex
-            for (int64_t i = data_count - 1; i >= 0; i--) {
-                auto old_offset = i * old_vertex_size;
-                auto new_offset = i * new_vertex_size;
-                memcpy(data.vertex_data + new_offset, data.vertex_data + old_offset, sizeof(double) * 2);
-                memcpy(data.vertex_data + new_offset + sizeof(double) * 2, &default_z, sizeof(double));
-                memcpy(data.vertex_data + new_offset + sizeof(double) * 3, &default_m, sizeof(double));
-            }
-        } else {
-            // Otherwise:
-            // 3. We go from XY to XYZ
-            // 4. We go from XY to XYM
-            // 5. We go from XYZ to XYZM
-            // These are all really the same, we just add the default to the end
-            auto default_value = has_m ? default_m : default_z;
-            for (int64_t i = data_count - 1; i >= 0; i--) {
-                auto old_offset = i * old_vertex_size;
-                auto new_offset = i * new_vertex_size;
-                memmove(data.vertex_data + new_offset, data.vertex_data + old_offset, old_vertex_size);
-                memcpy(data.vertex_data + new_offset + old_vertex_size, &default_value, sizeof(double));
-            }
-        }
-    }
-        // Case 2: The new vertex size is equal to the old vertex size
-    else if (new_vertex_size == old_vertex_size) {
-        // This only happens when we go from XYZ -> XYM or XYM -> XYZ
-        // In this case we just need to set the default on the third dimension
-        auto default_value = has_m ? default_m : default_z;
-        for (uint32_t i = 0; i < data_count; i++) {
-            auto offset = i * new_vertex_size + sizeof(double) * 2;
-            memcpy(data.vertex_data + offset, &default_value, sizeof(double));
-        }
-    }
-        // Case 3: The new vertex size is smaller than the old vertex size.
-        // In this case we need to allocate new memory and copy the data over to not lose any data
-    else {
-        auto new_data = alloc.AllocateAligned(data_count * new_vertex_size);
-        memset(new_data, 0, data_count * new_vertex_size);
+		// There are 5 cases here:
+		if (used_to_have_m && has_m && !used_to_have_z && has_z) {
+			// 1. We go from XYM to XYZM
+			// This is special, because we need to slide the M value to the end of each vertex
+			for (int64_t i = data_count - 1; i >= 0; i--) {
+				auto old_offset = i * old_vertex_size;
+				auto new_offset = i * new_vertex_size;
+				auto old_m_offset = old_offset + sizeof(double) * 2;
+				auto new_z_offset = new_offset + sizeof(double) * 2;
+				auto new_m_offset = new_offset + sizeof(double) * 3;
+				// Move the M value
+				memcpy(data.vertex_data + new_m_offset, data.vertex_data + old_m_offset, sizeof(double));
+				// Set the new Z value
+				memcpy(data.vertex_data + new_z_offset, &default_z, sizeof(double));
+				// Move the X and Y values
+				memcpy(data.vertex_data + new_offset, data.vertex_data + old_offset, sizeof(double) * 2);
+			}
+		} else if (!used_to_have_z && has_z && !used_to_have_m && has_m) {
+			// 2. We go from XY to XYZM
+			// This is special, because we need to add both the default Z and M values to the end of each vertex
+			for (int64_t i = data_count - 1; i >= 0; i--) {
+				auto old_offset = i * old_vertex_size;
+				auto new_offset = i * new_vertex_size;
+				memcpy(data.vertex_data + new_offset, data.vertex_data + old_offset, sizeof(double) * 2);
+				memcpy(data.vertex_data + new_offset + sizeof(double) * 2, &default_z, sizeof(double));
+				memcpy(data.vertex_data + new_offset + sizeof(double) * 3, &default_m, sizeof(double));
+			}
+		} else {
+			// Otherwise:
+			// 3. We go from XY to XYZ
+			// 4. We go from XY to XYM
+			// 5. We go from XYZ to XYZM
+			// These are all really the same, we just add the default to the end
+			auto default_value = has_m ? default_m : default_z;
+			for (int64_t i = data_count - 1; i >= 0; i--) {
+				auto old_offset = i * old_vertex_size;
+				auto new_offset = i * new_vertex_size;
+				memmove(data.vertex_data + new_offset, data.vertex_data + old_offset, old_vertex_size);
+				memcpy(data.vertex_data + new_offset + old_vertex_size, &default_value, sizeof(double));
+			}
+		}
+	}
+	// Case 2: The new vertex size is equal to the old vertex size
+	else if (new_vertex_size == old_vertex_size) {
+		// This only happens when we go from XYZ -> XYM or XYM -> XYZ
+		// In this case we just need to set the default on the third dimension
+		auto default_value = has_m ? default_m : default_z;
+		for (uint32_t i = 0; i < data_count; i++) {
+			auto offset = i * new_vertex_size + sizeof(double) * 2;
+			memcpy(data.vertex_data + offset, &default_value, sizeof(double));
+		}
+	}
+	// Case 3: The new vertex size is smaller than the old vertex size.
+	// In this case we need to allocate new memory and copy the data over to not lose any data
+	else {
+		auto new_data = alloc.AllocateAligned(data_count * new_vertex_size);
+		memset(new_data, 0, data_count * new_vertex_size);
 
-        // Special case: If we go from XYZM to XYM, we need to slide the M value to the end of each vertex
-        if (used_to_have_z && used_to_have_m && !has_z && has_m) {
-            for (uint32_t i = 0; i < data_count; i++) {
-                auto old_offset = i * old_vertex_size;
-                auto new_offset = i * new_vertex_size;
-                memcpy(new_data + new_offset, data.vertex_data + old_offset, sizeof(double) * 2);
-                auto m_offset = old_offset + sizeof(double) * 3;
-                memcpy(new_data + new_offset + sizeof(double) * 2, data.vertex_data + m_offset, sizeof(double));
-            }
-        } else {
-            // Otherwise, we just copy the data over
-            for (uint32_t i = 0; i < data_count; i++) {
-                auto old_offset = i * old_vertex_size;
-                auto new_offset = i * new_vertex_size;
-                memcpy(new_data + new_offset, data.vertex_data + old_offset, new_vertex_size);
-            }
-        }
-        data.vertex_data = new_data;
-    }
+		// Special case: If we go from XYZM to XYM, we need to slide the M value to the end of each vertex
+		if (used_to_have_z && used_to_have_m && !has_z && has_m) {
+			for (uint32_t i = 0; i < data_count; i++) {
+				auto old_offset = i * old_vertex_size;
+				auto new_offset = i * new_vertex_size;
+				memcpy(new_data + new_offset, data.vertex_data + old_offset, sizeof(double) * 2);
+				auto m_offset = old_offset + sizeof(double) * 3;
+				memcpy(new_data + new_offset + sizeof(double) * 2, data.vertex_data + m_offset, sizeof(double));
+			}
+		} else {
+			// Otherwise, we just copy the data over
+			for (uint32_t i = 0; i < data_count; i++) {
+				auto old_offset = i * old_vertex_size;
+				auto new_offset = i * new_vertex_size;
+				memcpy(new_data + new_offset, data.vertex_data + old_offset, new_vertex_size);
+			}
+		}
+		data.vertex_data = new_data;
+	}
 }
 
 void SinglePartGeometry::MakeMutable(ArenaAllocator &alloc) {
-    if (!IsReadOnly()) {
-        return;
-    }
-    if (data_count == 0) {
-        data.vertex_data = nullptr;
-        is_readonly = false;
-        return;
-    }
+	if (!IsReadOnly()) {
+		return;
+	}
+	if (data_count == 0) {
+		data.vertex_data = nullptr;
+		is_readonly = false;
+		return;
+	}
 
-    auto new_data = alloc.AllocateAligned(ByteSize());
-    memcpy(new_data, data.vertex_data, ByteSize());
-    data.vertex_data = new_data;
-    is_readonly = false;
+	auto new_data = alloc.AllocateAligned(ByteSize());
+	memcpy(new_data, data.vertex_data, ByteSize());
+	data.vertex_data = new_data;
+	is_readonly = false;
 }
 
-
 bool SinglePartGeometry::IsClosed() const {
-    switch(Count()) {
-        case 0: return false;
-        case 1: return true;
-        default:
-            auto first = Get(0);
-            auto last = Get(Count() - 1);
-            // TODO: Approximate comparison?
-            return first.x == last.x && first.y == last.y;
-    }
+	switch (Count()) {
+	case 0:
+		return false;
+	case 1:
+		return true;
+	default:
+		auto first = Get(0);
+		auto last = Get(Count() - 1);
+		// TODO: Approximate comparison?
+		return first.x == last.x && first.y == last.y;
+	}
 }
 
 double SinglePartGeometry::Length() const {
-    double length = 0;
-    for (uint32_t i = 1; i < Count(); i++) {
-        auto p1 = Get(i - 1);
-        auto p2 = Get(i);
-        length += sqrt((p2.x - p1.x) * (p2.x - p1.x) + (p2.y - p1.y) * (p2.y - p1.y));
-    }
-    return length;
+	double length = 0;
+	for (uint32_t i = 1; i < Count(); i++) {
+		auto p1 = Get(i - 1);
+		auto p2 = Get(i);
+		length += sqrt((p2.x - p1.x) * (p2.x - p1.x) + (p2.y - p1.y) * (p2.y - p1.y));
+	}
+	return length;
 }
 
-
 string SinglePartGeometry::ToString(uint32_t start, uint32_t count) const {
-    auto has_z = properties.HasZ();
-    auto has_m = properties.HasM();
+	auto has_z = properties.HasZ();
+	auto has_m = properties.HasM();
 
-    D_ASSERT(type == GeometryType::POINT || type == GeometryType::LINESTRING);
-    auto type_name = type == GeometryType::POINT ? "POINT" : "LINESTRING";
+	D_ASSERT(type == GeometryType::POINT || type == GeometryType::LINESTRING);
+	auto type_name = type == GeometryType::POINT ? "POINT" : "LINESTRING";
 
-    if (has_z && has_m) {
-        string result = StringUtil::Format("%s XYZM ([%d-%d]/%d) [", type_name, start, start + count, data_count);
-        for (uint32_t i = start; i < count; i++) {
-            auto vertex = GetExact<VertexXYZM>(i);
-            result += StringUtil::Format("(%f, %f, %f, %f)", vertex.x, vertex.y, vertex.z, vertex.m);
-            if (i < count - 1) {
-                result += ", ";
-            }
-        }
-        result += "]";
-        return result;
-    } else if (has_z) {
-        string result = StringUtil::Format("%s XYZ ([%d-%d]/%d) [", type_name, start, start + count, data_count);
-        for (uint32_t i = start; i < count; i++) {
-            auto vertex = GetExact<VertexXYZ>(i);
-            result += StringUtil::Format("(%f, %f, %f)", vertex.x, vertex.y, vertex.z);
-            if (i < count - 1) {
-                result += ", ";
-            }
-        }
-        result += "]";
-        return result;
-    } else if (has_m) {
-        string result = StringUtil::Format("%s XYM ([%d-%d]/%d) [", type_name, start, start + count, data_count);
-        for (uint32_t i = start; i < count; i++) {
-            auto vertex = GetExact<VertexXYM>(i);
-            result += StringUtil::Format("(%f, %f, %f)", vertex.x, vertex.y, vertex.m);
-            if (i < count - 1) {
-                result += ", ";
-            }
-        }
-        result += "]";
-        return result;
-    } else {
-        string result = StringUtil::Format("%s XY ([%d-%d]/%d) [", type_name, start, start + count, data_count);
-        for (uint32_t i = start; i < count; i++) {
-            auto vertex = GetExact<VertexXY>(i);
-            result += StringUtil::Format("(%f, %f)", vertex.x, vertex.y);
-            if (i < count - 1) {
-                result += ", ";
-            }
-        }
-        result += "]";
-        return result;
-    }
+	if (has_z && has_m) {
+		string result = StringUtil::Format("%s XYZM ([%d-%d]/%d) [", type_name, start, start + count, data_count);
+		for (uint32_t i = start; i < count; i++) {
+			auto vertex = GetExact<VertexXYZM>(i);
+			result += StringUtil::Format("(%f, %f, %f, %f)", vertex.x, vertex.y, vertex.z, vertex.m);
+			if (i < count - 1) {
+				result += ", ";
+			}
+		}
+		result += "]";
+		return result;
+	} else if (has_z) {
+		string result = StringUtil::Format("%s XYZ ([%d-%d]/%d) [", type_name, start, start + count, data_count);
+		for (uint32_t i = start; i < count; i++) {
+			auto vertex = GetExact<VertexXYZ>(i);
+			result += StringUtil::Format("(%f, %f, %f)", vertex.x, vertex.y, vertex.z);
+			if (i < count - 1) {
+				result += ", ";
+			}
+		}
+		result += "]";
+		return result;
+	} else if (has_m) {
+		string result = StringUtil::Format("%s XYM ([%d-%d]/%d) [", type_name, start, start + count, data_count);
+		for (uint32_t i = start; i < count; i++) {
+			auto vertex = GetExact<VertexXYM>(i);
+			result += StringUtil::Format("(%f, %f, %f)", vertex.x, vertex.y, vertex.m);
+			if (i < count - 1) {
+				result += ", ";
+			}
+		}
+		result += "]";
+		return result;
+	} else {
+		string result = StringUtil::Format("%s XY ([%d-%d]/%d) [", type_name, start, start + count, data_count);
+		for (uint32_t i = start; i < count; i++) {
+			auto vertex = GetExact<VertexXY>(i);
+			result += StringUtil::Format("(%f, %f)", vertex.x, vertex.y);
+			if (i < count - 1) {
+				result += ", ";
+			}
+		}
+		result += "]";
+		return result;
+	}
 }
 
 //------------------------------------------------------------------------------
@@ -293,193 +296,191 @@ string SinglePartGeometry::ToString(uint32_t start, uint32_t count) const {
 //------------------------------------------------------------------------------
 
 void MultiPartGeometry::Resize(ArenaAllocator &alloc, uint32_t new_count) {
-    if (new_count == data_count) {
-        return;
-    }
-    if (data.part_data == nullptr) {
-        data.part_data = reinterpret_cast<Geometry*>(alloc.AllocateAligned(sizeof(Geometry) * new_count));
-    } else {
-        data.part_data = reinterpret_cast<Geometry *>(alloc.ReallocateAligned(data_ptr_cast(data.part_data),
-                                                                              data_count * sizeof(Geometry),
-                                                                              new_count * sizeof(Geometry)));
-    }
-    data_count = new_count;
+	if (new_count == data_count) {
+		return;
+	}
+	if (data.part_data == nullptr) {
+		data.part_data = reinterpret_cast<Geometry *>(alloc.AllocateAligned(sizeof(Geometry) * new_count));
+	} else {
+		data.part_data = reinterpret_cast<Geometry *>(alloc.ReallocateAligned(
+		    data_ptr_cast(data.part_data), data_count * sizeof(Geometry), new_count * sizeof(Geometry)));
+	}
+	data_count = new_count;
 }
-
 
 /*
 string Point::ToString() const {
-	if (IsEmpty()) {
-		return "POINT EMPTY";
-	}
-	auto vert = vertices.Get(0);
-	if (std::isnan(vert.x) && std::isnan(vert.y)) {
-		// This is a special case for WKB. WKB does not support empty points,
-		// and instead writes a point with NaN coordinates. We therefore need to
-		// check for this case and return POINT EMPTY instead to round-trip safely
-		return "POINT EMPTY";
-	}
-	return StringUtil::Format("POINT (%s)", Utils::format_coord(vert.x, vert.y));
+    if (IsEmpty()) {
+        return "POINT EMPTY";
+    }
+    auto vert = vertices.Get(0);
+    if (std::isnan(vert.x) && std::isnan(vert.y)) {
+        // This is a special case for WKB. WKB does not support empty points,
+        // and instead writes a point with NaN coordinates. We therefore need to
+        // check for this case and return POINT EMPTY instead to round-trip safely
+        return "POINT EMPTY";
+    }
+    return StringUtil::Format("POINT (%s)", Utils::format_coord(vert.x, vert.y));
 }
 
 string LineString::ToString() const {
-	auto count = vertices.Count();
-	if (count == 0) {
-		return "LINESTRING EMPTY";
-	}
+    auto count = vertices.Count();
+    if (count == 0) {
+        return "LINESTRING EMPTY";
+    }
 
-	string result = "LINESTRING (";
-	for (uint32_t i = 0; i < vertices.Count(); i++) {
-		auto x = vertices.Get(i).x;
-		auto y = vertices.Get(i).y;
-		result += Utils::format_coord(x, y);
-		if (i < vertices.Count() - 1) {
-			result += ", ";
-		}
-	}
-	result += ")";
-	return result;
+    string result = "LINESTRING (";
+    for (uint32_t i = 0; i < vertices.Count(); i++) {
+        auto x = vertices.Get(i).x;
+        auto y = vertices.Get(i).y;
+        result += Utils::format_coord(x, y);
+        if (i < vertices.Count() - 1) {
+            result += ", ";
+        }
+    }
+    result += ")";
+    return result;
 }
 
 string Polygon::ToString() const {
 
-	// check if the polygon is empty
-	uint32_t total_verts = 0;
-	auto num_rings = ring_count;
-	for (uint32_t i = 0; i < num_rings; i++) {
-		total_verts += rings[i].Count();
-	}
-	if (total_verts == 0) {
-		return "POLYGON EMPTY";
-	}
+    // check if the polygon is empty
+    uint32_t total_verts = 0;
+    auto num_rings = ring_count;
+    for (uint32_t i = 0; i < num_rings; i++) {
+        total_verts += rings[i].Count();
+    }
+    if (total_verts == 0) {
+        return "POLYGON EMPTY";
+    }
 
-	string result = "POLYGON (";
-	for (uint32_t i = 0; i < num_rings; i++) {
-		result += "(";
-		for (uint32_t j = 0; j < rings[i].Count(); j++) {
-			auto x = rings[i].Get(j).x;
-			auto y = rings[i].Get(j).y;
-			result += Utils::format_coord(x, y);
-			if (j < rings[i].Count() - 1) {
-				result += ", ";
-			}
-		}
-		result += ")";
-		if (i < num_rings - 1) {
-			result += ", ";
-		}
-	}
-	result += ")";
-	return result;
+    string result = "POLYGON (";
+    for (uint32_t i = 0; i < num_rings; i++) {
+        result += "(";
+        for (uint32_t j = 0; j < rings[i].Count(); j++) {
+            auto x = rings[i].Get(j).x;
+            auto y = rings[i].Get(j).y;
+            result += Utils::format_coord(x, y);
+            if (j < rings[i].Count() - 1) {
+                result += ", ";
+            }
+        }
+        result += ")";
+        if (i < num_rings - 1) {
+            result += ", ";
+        }
+    }
+    result += ")";
+    return result;
 }
 
 string MultiPoint::ToString() const {
-	auto num_points = ItemCount();
-	if (num_points == 0) {
-		return "MULTIPOINT EMPTY";
-	}
-	string str = "MULTIPOINT (";
-	auto &points = *this;
-	for (uint32_t i = 0; i < num_points; i++) {
-		auto &point = points[i];
-		if (point.IsEmpty()) {
-			str += "EMPTY";
-		} else {
-			auto vert = point.Vertices().Get(0);
-			str += Utils::format_coord(vert.x, vert.y);
-		}
-		if (i < num_points - 1) {
-			str += ", ";
-		}
-	}
-	return str + ")";
+    auto num_points = ItemCount();
+    if (num_points == 0) {
+        return "MULTIPOINT EMPTY";
+    }
+    string str = "MULTIPOINT (";
+    auto &points = *this;
+    for (uint32_t i = 0; i < num_points; i++) {
+        auto &point = points[i];
+        if (point.IsEmpty()) {
+            str += "EMPTY";
+        } else {
+            auto vert = point.Vertices().Get(0);
+            str += Utils::format_coord(vert.x, vert.y);
+        }
+        if (i < num_points - 1) {
+            str += ", ";
+        }
+    }
+    return str + ")";
 }
 
 
 string MultiLineString::ToString() const {
-	auto count = ItemCount();
-	if (count == 0) {
-		return "MULTILINESTRING EMPTY";
-	}
-	string str = "MULTILINESTRING (";
+    auto count = ItemCount();
+    if (count == 0) {
+        return "MULTILINESTRING EMPTY";
+    }
+    string str = "MULTILINESTRING (";
 
-	bool first_line = true;
-	for (auto &line : *this) {
-		if (first_line) {
-			first_line = false;
-		} else {
-			str += ", ";
-		}
-		str += "(";
-		bool first_vert = true;
-		for (uint32_t i = 0; i < line.Vertices().Count(); i++) {
-			auto vert = line.Vertices().Get(i);
-			if (first_vert) {
-				first_vert = false;
-			} else {
-				str += ", ";
-			}
-			str += Utils::format_coord(vert.x, vert.y);
-		}
-		str += ")";
-	}
-	return str + ")";
+    bool first_line = true;
+    for (auto &line : *this) {
+        if (first_line) {
+            first_line = false;
+        } else {
+            str += ", ";
+        }
+        str += "(";
+        bool first_vert = true;
+        for (uint32_t i = 0; i < line.Vertices().Count(); i++) {
+            auto vert = line.Vertices().Get(i);
+            if (first_vert) {
+                first_vert = false;
+            } else {
+                str += ", ";
+            }
+            str += Utils::format_coord(vert.x, vert.y);
+        }
+        str += ")";
+    }
+    return str + ")";
 }
 
 string MultiPolygon::ToString() const {
-	auto count = ItemCount();
-	if (count == 0) {
-		return "MULTIPOLYGON EMPTY";
-	}
-	string str = "MULTIPOLYGON (";
+    auto count = ItemCount();
+    if (count == 0) {
+        return "MULTIPOLYGON EMPTY";
+    }
+    string str = "MULTIPOLYGON (";
 
-	bool first_poly = true;
-	for (auto &poly : *this) {
-		if (first_poly) {
-			first_poly = false;
-		} else {
-			str += ", ";
-		}
-		str += "(";
-		bool first_ring = true;
-		for (auto &ring : poly) {
-			if (first_ring) {
-				first_ring = false;
-			} else {
-				str += ", ";
-			}
-			str += "(";
-			bool first_vert = true;
-			for (uint32_t v = 0; v < ring.Count(); v++) {
-				auto vert = ring.Get(v);
-				if (first_vert) {
-					first_vert = false;
-				} else {
-					str += ", ";
-				}
-				str += Utils::format_coord(vert.x, vert.y);
-			}
-			str += ")";
-		}
-		str += ")";
-	}
+    bool first_poly = true;
+    for (auto &poly : *this) {
+        if (first_poly) {
+            first_poly = false;
+        } else {
+            str += ", ";
+        }
+        str += "(";
+        bool first_ring = true;
+        for (auto &ring : poly) {
+            if (first_ring) {
+                first_ring = false;
+            } else {
+                str += ", ";
+            }
+            str += "(";
+            bool first_vert = true;
+            for (uint32_t v = 0; v < ring.Count(); v++) {
+                auto vert = ring.Get(v);
+                if (first_vert) {
+                    first_vert = false;
+                } else {
+                    str += ", ";
+                }
+                str += Utils::format_coord(vert.x, vert.y);
+            }
+            str += ")";
+        }
+        str += ")";
+    }
 
-	return str + ")";
+    return str + ")";
 }
 
 string GeometryCollection::ToString() const {
-	auto count = ItemCount();
-	if (count == 0) {
-		return "GEOMETRYCOLLECTION EMPTY";
-	}
-	string str = "GEOMETRYCOLLECTION (";
-	for (uint32_t i = 0; i < count; i++) {
-		str += (*this)[i].ToString();
-		if (i < count - 1) {
-			str += ", ";
-		}
-	}
-	return str + ")";
+    auto count = ItemCount();
+    if (count == 0) {
+        return "GEOMETRYCOLLECTION EMPTY";
+    }
+    string str = "GEOMETRYCOLLECTION (";
+    for (uint32_t i = 0; i < count; i++) {
+        str += (*this)[i].ToString();
+        if (i < count - 1) {
+            str += ", ";
+        }
+    }
+    return str + ")";
 }
 */
 
@@ -490,43 +491,43 @@ string GeometryCollection::ToString() const {
 extern "C" int geos_d2sfixed_buffered_n(double f, uint32_t precision, char *result);
 
 string Utils::format_coord(double d) {
-    char buf[25];
-    auto len = geos_d2sfixed_buffered_n(d, 15, buf);
-    buf[len] = '\0';
-    return string {buf};
+	char buf[25];
+	auto len = geos_d2sfixed_buffered_n(d, 15, buf);
+	buf[len] = '\0';
+	return string {buf};
 }
 
 string Utils::format_coord(double x, double y) {
-    char buf[51];
-    auto res_x = geos_d2sfixed_buffered_n(x, 15, buf);
-    buf[res_x++] = ' ';
-    auto res_y = geos_d2sfixed_buffered_n(y, 15, buf + res_x);
-    buf[res_x + res_y] = '\0';
-    return string {buf};
+	char buf[51];
+	auto res_x = geos_d2sfixed_buffered_n(x, 15, buf);
+	buf[res_x++] = ' ';
+	auto res_y = geos_d2sfixed_buffered_n(y, 15, buf + res_x);
+	buf[res_x + res_y] = '\0';
+	return string {buf};
 }
 
 string Utils::format_coord(double x, double y, double zm) {
-    char buf[76];
-    auto res_x = geos_d2sfixed_buffered_n(x, 15, buf);
-    buf[res_x++] = ' ';
-    auto res_y = geos_d2sfixed_buffered_n(y, 15, buf + res_x);
-    buf[res_x + res_y++] = ' ';
-    auto res_zm = geos_d2sfixed_buffered_n(zm, 15, buf + res_x + res_y);
-    buf[res_x + res_y + res_zm] = '\0';
-    return string {buf};
+	char buf[76];
+	auto res_x = geos_d2sfixed_buffered_n(x, 15, buf);
+	buf[res_x++] = ' ';
+	auto res_y = geos_d2sfixed_buffered_n(y, 15, buf + res_x);
+	buf[res_x + res_y++] = ' ';
+	auto res_zm = geos_d2sfixed_buffered_n(zm, 15, buf + res_x + res_y);
+	buf[res_x + res_y + res_zm] = '\0';
+	return string {buf};
 }
 
 string Utils::format_coord(double x, double y, double z, double m) {
-    char buf[101];
-    auto res_x = geos_d2sfixed_buffered_n(x, 15, buf);
-    buf[res_x++] = ' ';
-    auto res_y = geos_d2sfixed_buffered_n(y, 15, buf + res_x);
-    buf[res_x + res_y++] = ' ';
-    auto res_z = geos_d2sfixed_buffered_n(z, 15, buf + res_x + res_y);
-    buf[res_x + res_y + res_z++] = ' ';
-    auto res_m = geos_d2sfixed_buffered_n(m, 15, buf + res_x + res_y + res_z);
-    buf[res_x + res_y + res_z + res_m] = '\0';
-    return string {buf};
+	char buf[101];
+	auto res_x = geos_d2sfixed_buffered_n(x, 15, buf);
+	buf[res_x++] = ' ';
+	auto res_y = geos_d2sfixed_buffered_n(y, 15, buf + res_x);
+	buf[res_x + res_y++] = ' ';
+	auto res_z = geos_d2sfixed_buffered_n(z, 15, buf + res_x + res_y);
+	buf[res_x + res_y + res_z++] = ' ';
+	auto res_m = geos_d2sfixed_buffered_n(m, 15, buf + res_x + res_y + res_z);
+	buf[res_x + res_y + res_z + res_m] = '\0';
+	return string {buf};
 }
 
 } // namespace core

--- a/spatial/src/spatial/core/geometry/wkb_reader.cpp
+++ b/spatial/src/spatial/core/geometry/wkb_reader.cpp
@@ -89,7 +89,7 @@ Point WKBReader::ReadPoint(Cursor &cursor, bool little_endian, bool has_z, bool 
 	if (all_nan) {
 		return Point(has_z, has_m);
 	} else {
-        return Point::CopyFromData(arena, data_ptr_cast(coords), 1, has_z, has_m);
+		return Point::CopyFromData(arena, data_ptr_cast(coords), 1, has_z, has_m);
 	}
 }
 

--- a/spatial/src/spatial/core/geometry/wkb_reader.cpp
+++ b/spatial/src/spatial/core/geometry/wkb_reader.cpp
@@ -28,9 +28,7 @@ uint32_t WKBReader::ReadInt(Cursor &cursor, bool little_endian) {
 	if (little_endian) {
 		return cursor.Read<uint32_t>();
 	} else {
-		auto data = cursor.template Read<uint32_t>();
-		// swap bytes
-		return (data >> 24) | ((data >> 8) & 0xFF00) | ((data << 8) & 0xFF0000) | (data << 24);
+		return cursor.ReadBigEndian<uint32_t>();
 	}
 }
 
@@ -38,13 +36,7 @@ double WKBReader::ReadDouble(Cursor &cursor, bool little_endian) {
 	if (little_endian) {
 		return cursor.Read<double>();
 	} else {
-		auto data = cursor.template Read<uint64_t>();
-		// swap bytes
-		data = (data & 0x00000000FF000000) << 24 | (data & 0x000000FF00000000) << 8 | (data & 0x0000FF0000000000) >> 8 |
-		       (data & 0xFF00000000000000) >> 24;
-		double result;
-		memcpy(&result, &data, sizeof(double));
-		return result;
+		return cursor.ReadBigEndian<double>();
 	}
 }
 
@@ -93,12 +85,36 @@ Point WKBReader::ReadPoint(Cursor &cursor, bool little_endian, bool has_z, bool 
 	}
 }
 
+void WKBReader::ReadVertices(Cursor &cursor, bool little_endian, bool has_z, bool has_m, SinglePartGeometry &geometry) {
+	for (uint32_t i = 0; i < geometry.Count(); i++) {
+		if (has_z && has_m) {
+			auto x = ReadDouble(cursor, little_endian);
+			auto y = ReadDouble(cursor, little_endian);
+			auto z = ReadDouble(cursor, little_endian);
+			auto m = ReadDouble(cursor, little_endian);
+			geometry.SetExact(i, VertexXYZM {x, y, z, m});
+		} else if (has_z) {
+			auto x = ReadDouble(cursor, little_endian);
+			auto y = ReadDouble(cursor, little_endian);
+			auto z = ReadDouble(cursor, little_endian);
+			geometry.SetExact(i, VertexXYZ {x, y, z});
+		} else if (has_m) {
+			auto x = ReadDouble(cursor, little_endian);
+			auto y = ReadDouble(cursor, little_endian);
+			auto m = ReadDouble(cursor, little_endian);
+			geometry.SetExact(i, VertexXYM {x, y, m});
+		} else {
+			auto x = ReadDouble(cursor, little_endian);
+			auto y = ReadDouble(cursor, little_endian);
+			geometry.SetExact(i, VertexXY {x, y});
+		}
+	}
+}
+
 LineString WKBReader::ReadLineString(Cursor &cursor, bool little_endian, bool has_z, bool has_m) {
 	auto count = ReadInt(cursor, little_endian);
-	auto ptr = cursor.GetPtr();
-	auto vertices = LineString::CopyFromData(arena, ptr, count, has_z, has_m);
-	// Move the cursor forwards
-	cursor.Skip(vertices.ByteSize());
+	LineString vertices(arena, count, has_z, has_m);
+	ReadVertices(cursor, little_endian, has_z, has_m, vertices);
 	return vertices;
 }
 
@@ -107,9 +123,8 @@ Polygon WKBReader::ReadPolygon(Cursor &cursor, bool little_endian, bool has_z, b
 	Polygon polygon(arena, ring_count, has_z, has_m);
 	for (uint32_t i = 0; i < ring_count; i++) {
 		auto point_count = ReadInt(cursor, little_endian);
-		auto vertices = LineString::CopyFromData(arena, cursor.GetPtr(), point_count, has_z, has_m);
-		cursor.Skip(vertices.ByteSize());
-		polygon[i] = vertices;
+		polygon[i].Resize(arena, point_count);
+		ReadVertices(cursor, little_endian, has_z, has_m, polygon[i]);
 	}
 	return polygon;
 }

--- a/spatial/src/spatial/core/geometry/wkt_reader.cpp
+++ b/spatial/src/spatial/core/geometry/wkt_reader.cpp
@@ -109,9 +109,9 @@ void WKTReader::ParseVertex(vector<double> &coords) {
 }
 
 pair<uint32_t, vector<double>> WKTReader::ParseVertices() {
-    vector<double> coords;
+	vector<double> coords;
 	if (MatchCI("EMPTY")) {
-        return {0, coords};
+		return {0, coords};
 	}
 	Expect('(');
 	uint32_t count = 0;
@@ -122,7 +122,7 @@ pair<uint32_t, vector<double>> WKTReader::ParseVertices() {
 		count++;
 	}
 	Expect(')');
-    return {count, coords};
+	return {count, coords};
 }
 
 Point WKTReader::ParsePoint() {
@@ -133,12 +133,12 @@ Point WKTReader::ParsePoint() {
 	vector<double> coords;
 	ParseVertex(coords);
 	Expect(')');
-    return Point::CopyFromData(arena, data_ptr_cast(coords.data()), 1, has_z, has_m);
+	return Point::CopyFromData(arena, data_ptr_cast(coords.data()), 1, has_z, has_m);
 }
 
 LineString WKTReader::ParseLineString() {
-    auto verts = ParseVertices();
-    return LineString::CopyFromData(arena, data_ptr_cast(verts.second.data()), verts.first, has_z, has_m);
+	auto verts = ParseVertices();
+	return LineString::CopyFromData(arena, data_ptr_cast(verts.second.data()), verts.first, has_z, has_m);
 }
 
 Polygon WKTReader::ParsePolygon() {
@@ -188,7 +188,7 @@ MultiPoint WKTReader::ParseMultiPoint() {
 			Expect(')');
 			optional_paren = false;
 		}
-        points.push_back(Point::CopyFromData(arena, data_ptr_cast(coords.data()), 1, has_z, has_m));
+		points.push_back(Point::CopyFromData(arena, data_ptr_cast(coords.data()), 1, has_z, has_m));
 		coords.clear();
 	}
 	Expect(')');

--- a/spatial/src/spatial/core/io/shapefile/read_shapefile.cpp
+++ b/spatial/src/spatial/core/io/shapefile/read_shapefile.cpp
@@ -180,7 +180,7 @@ struct ShapefileGlobalState : public GlobalTableFunctionState {
 	int shape_idx;
 	SHPHandlePtr shp_handle;
 	DBFHandlePtr dbf_handle;
-    ArenaAllocator arena;
+	ArenaAllocator arena;
 	vector<idx_t> column_ids;
 
 	explicit ShapefileGlobalState(ClientContext &context, const string &file_name, vector<idx_t> column_ids_p)
@@ -208,7 +208,7 @@ static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, T
 
 struct ConvertPoint {
 	static Geometry Convert(SHPObjectPtr &shape, ArenaAllocator &arena) {
-		return Point::FromVertex(arena, VertexXY { shape->padfX[0], shape->padfY[0] });
+		return Point::FromVertex(arena, VertexXY {shape->padfX[0], shape->padfY[0]});
 	}
 };
 
@@ -218,7 +218,7 @@ struct ConvertLineString {
 			// Single LineString
 			LineString line(arena, shape->nVertices, false, false);
 			for (int i = 0; i < shape->nVertices; i++) {
-				line.SetExact(i, VertexXY { shape->padfX[i], shape->padfY[i] });
+				line.SetExact(i, VertexXY {shape->padfX[i], shape->padfY[i]});
 			}
 			return line;
 		} else {
@@ -229,10 +229,10 @@ struct ConvertLineString {
 				auto end = i == shape->nParts - 1 ? shape->nVertices : shape->panPartStart[i + 1];
 				auto line_size = end - start;
 				auto &line = multi_line_string[i];
-                line.Resize(arena, line_size);
+				line.Resize(arena, line_size);
 				for (int j = 0; j < line_size; j++) {
 					auto offset = start + j;
-					line.SetExact(j, VertexXY { shape->padfX[offset], shape->padfY[offset] });
+					line.SetExact(j, VertexXY {shape->padfX[offset], shape->padfY[offset]});
 				}
 				start = end;
 			}
@@ -294,7 +294,7 @@ struct ConvertPolygon {
 					ring.Resize(arena, ring_size);
 					for (int j = 0; j < ring_size; j++) {
 						auto offset = start + j;
-						ring.SetExact(j, VertexXY { shape->padfX[offset], shape->padfY[offset] });
+						ring.SetExact(j, VertexXY {shape->padfX[offset], shape->padfY[offset]});
 					}
 				}
 				multi_polygon[polygon_idx] = polygon;
@@ -308,7 +308,7 @@ struct ConvertMultiPoint {
 	static Geometry Convert(SHPObjectPtr &shape, ArenaAllocator &arena) {
 		MultiPoint multi_point(arena, shape->nVertices, false, false);
 		for (int i = 0; i < shape->nVertices; i++) {
-			multi_point[i] = Point::FromVertex(arena, VertexXY { shape->padfX[i], shape->padfY[i] });
+			multi_point[i] = Point::FromVertex(arena, VertexXY {shape->padfX[i], shape->padfY[i]});
 		}
 		return multi_point;
 	}

--- a/spatial/src/spatial/gdal/file_handler.cpp
+++ b/spatial/src/spatial/gdal/file_handler.cpp
@@ -177,13 +177,19 @@ public:
 				return new DuckDBFileHandle(std::move(file));
 			}
 #endif
-			auto file = fs.OpenFile(file_name, flags, FileSystem::DEFAULT_LOCK, FileCompressionType::AUTO_DETECT);
+
 			// If the file is remote and NOT in write mode, we can cache it.
-			if (!file->OnDiskFile() && !(flags & FileFlags::FILE_FLAGS_WRITE) &&
+			if (FileSystem::IsRemoteFile(file_name_str) && !(flags & FileFlags::FILE_FLAGS_WRITE) &&
 			    !(flags & FileFlags::FILE_FLAGS_APPEND)) {
-				return VSICreateCachedFile(new DuckDBFileHandle(std::move(file)));
+
+                // Pass the direct IO flag to the file system since we use GDAL's caching instead
+                flags |= FileFlags::FILE_FLAGS_DIRECT_IO;
+
+                auto file = fs.OpenFile(file_name, flags, FileSystem::DEFAULT_LOCK, FileCompressionType::AUTO_DETECT);
+                return VSICreateCachedFile(new DuckDBFileHandle(std::move(file)));
 			} else {
-				return new DuckDBFileHandle(std::move(file));
+                auto file = fs.OpenFile(file_name, flags, FileSystem::DEFAULT_LOCK, FileCompressionType::AUTO_DETECT);
+                return new DuckDBFileHandle(std::move(file));
 			}
 		} catch (std::exception &ex) {
 			// Failed to open file via DuckDB File System. If this doesnt have a VSI prefix we can return an error here.
@@ -373,8 +379,12 @@ void GDALClientContextState::QueryEnd() {
 
 };
 
-const string &GDALClientContextState::GetPrefix() const {
-	return client_prefix;
+string GDALClientContextState::GetPrefix(const string &value) const {
+    // If the user explicitly asked for a VSI prefix, we don't add our own
+    if(StringUtil::StartsWith(value, "/vsi")) {
+        return value;
+    }
+	return client_prefix + value;
 }
 
 GDALClientContextState &GDALClientContextState::GetOrCreate(ClientContext &context) {

--- a/spatial/src/spatial/gdal/file_handler.cpp
+++ b/spatial/src/spatial/gdal/file_handler.cpp
@@ -182,14 +182,14 @@ public:
 			if (FileSystem::IsRemoteFile(file_name_str) && !(flags & FileFlags::FILE_FLAGS_WRITE) &&
 			    !(flags & FileFlags::FILE_FLAGS_APPEND)) {
 
-                // Pass the direct IO flag to the file system since we use GDAL's caching instead
-                flags |= FileFlags::FILE_FLAGS_DIRECT_IO;
+				// Pass the direct IO flag to the file system since we use GDAL's caching instead
+				flags |= FileFlags::FILE_FLAGS_DIRECT_IO;
 
-                auto file = fs.OpenFile(file_name, flags, FileSystem::DEFAULT_LOCK, FileCompressionType::AUTO_DETECT);
-                return VSICreateCachedFile(new DuckDBFileHandle(std::move(file)));
+				auto file = fs.OpenFile(file_name, flags, FileSystem::DEFAULT_LOCK, FileCompressionType::AUTO_DETECT);
+				return VSICreateCachedFile(new DuckDBFileHandle(std::move(file)));
 			} else {
-                auto file = fs.OpenFile(file_name, flags, FileSystem::DEFAULT_LOCK, FileCompressionType::AUTO_DETECT);
-                return new DuckDBFileHandle(std::move(file));
+				auto file = fs.OpenFile(file_name, flags, FileSystem::DEFAULT_LOCK, FileCompressionType::AUTO_DETECT);
+				return new DuckDBFileHandle(std::move(file));
 			}
 		} catch (std::exception &ex) {
 			// Failed to open file via DuckDB File System. If this doesnt have a VSI prefix we can return an error here.
@@ -380,10 +380,10 @@ void GDALClientContextState::QueryEnd() {
 };
 
 string GDALClientContextState::GetPrefix(const string &value) const {
-    // If the user explicitly asked for a VSI prefix, we don't add our own
-    if(StringUtil::StartsWith(value, "/vsi")) {
-        return value;
-    }
+	// If the user explicitly asked for a VSI prefix, we don't add our own
+	if (StringUtil::StartsWith(value, "/vsi")) {
+		return value;
+	}
 	return client_prefix + value;
 }
 

--- a/spatial/src/spatial/gdal/functions/st_read.cpp
+++ b/spatial/src/spatial/gdal/functions/st_read.cpp
@@ -187,7 +187,7 @@ unique_ptr<FunctionData> GdalTableFunction::Bind(ClientContext &context, TableFu
 	auto &ctx_state = GDALClientContextState::GetOrCreate(context);
 
 	result->raw_file_name = input.inputs[0].GetValue<string>();
-	result->prefixed_file_name = ctx_state.GetPrefix() + result->raw_file_name;
+	result->prefixed_file_name = ctx_state.GetPrefix(result->raw_file_name);
 
 	auto dataset = GDALDatasetUniquePtr(GDALDataset::Open(
 	    result->prefixed_file_name.c_str(), GDAL_OF_VECTOR | GDAL_OF_VERBOSE_ERROR, result->dataset_allowed_drivers,

--- a/spatial/src/spatial/gdal/functions/st_read.cpp
+++ b/spatial/src/spatial/gdal/functions/st_read.cpp
@@ -135,8 +135,7 @@ struct GdalScanLocalState : ArrowScanLocalState {
 	// We trust GDAL to produce valid WKB
 	core::WKBReader wkb_reader;
 	explicit GdalScanLocalState(unique_ptr<ArrowArrayWrapper> current_chunk, ClientContext &context)
-	    : ArrowScanLocalState(std::move(current_chunk)), arena(BufferAllocator::Get(context)),
-	      wkb_reader(arena) {
+	    : ArrowScanLocalState(std::move(current_chunk)), arena(BufferAllocator::Get(context)), wkb_reader(arena) {
 	}
 };
 

--- a/spatial/src/spatial/gdal/functions/st_read_meta.cpp
+++ b/spatial/src/spatial/gdal/functions/st_read_meta.cpp
@@ -184,7 +184,7 @@ static void Scan(ClientContext &context, TableFunctionInput &input, DataChunk &o
 
 	for (idx_t out_idx = 0; out_idx < out_size; out_idx++, state.current_file_idx++) {
 		auto file_name = bind_data.file_names[state.current_file_idx];
-		auto prefixed_file_name = GDALClientContextState::GetOrCreate(context).GetPrefix() + file_name;
+		auto prefixed_file_name = GDALClientContextState::GetOrCreate(context).GetPrefix(file_name);
 
 		GDALDatasetUniquePtr dataset;
 		try {

--- a/spatial/src/spatial/gdal/functions/st_write.cpp
+++ b/spatial/src/spatial/gdal/functions/st_write.cpp
@@ -285,7 +285,7 @@ static unique_ptr<GlobalFunctionData> InitGlobal(ClientContext &context, Functio
 
 	// Create the dataset
 	auto &client_ctx = GDALClientContextState::GetOrCreate(context);
-	auto prefixed_path = client_ctx.GetPrefix() + file_path;
+	auto prefixed_path = client_ctx.GetPrefix(file_path);
 	auto dataset = GDALDatasetUniquePtr(
 	    driver->Create(prefixed_path.c_str(), 0, 0, 0, GDT_Unknown, gdal_data.dataset_creation_options));
 	if (!dataset) {

--- a/spatial/src/spatial/gdal/functions/st_write.cpp
+++ b/spatial/src/spatial/gdal/functions/st_write.cpp
@@ -38,7 +38,7 @@ struct BindData : public TableFunctionData {
 };
 
 struct LocalState : public LocalFunctionData {
-    ArenaAllocator arena;
+	ArenaAllocator arena;
 	explicit LocalState(ClientContext &context) : arena(BufferAllocator::Get(context)) {
 	}
 };
@@ -337,8 +337,7 @@ static unique_ptr<GlobalFunctionData> InitGlobal(ClientContext &context, Functio
 // Sink
 //===--------------------------------------------------------------------===//
 
-static OGRGeometryUniquePtr OGRGeometryFromValue(const LogicalType &type, const Value &value,
-                                                 ArenaAllocator &arena) {
+static OGRGeometryUniquePtr OGRGeometryFromValue(const LogicalType &type, const Value &value, ArenaAllocator &arena) {
 	if (type == core::GeoTypes::WKB_BLOB()) {
 		auto str = value.GetValueUnsafe<string_t>();
 

--- a/spatial/src/spatial/geographiclib/functions/st_perimeter_spheroid.cpp
+++ b/spatial/src/spatial/geographiclib/functions/st_perimeter_spheroid.cpp
@@ -91,7 +91,7 @@ static double PolygonPerimeter(const Polygon &poly, GeographicLib::PolygonArea &
 
 static void GeodesicGeometryFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GeometryFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 
 	auto &input = args.data[0];
 	auto count = args.size();
@@ -99,35 +99,34 @@ static void GeodesicGeometryFunction(DataChunk &args, ExpressionState &state, Ve
 	const GeographicLib::Geodesic &geod = GeographicLib::Geodesic::WGS84();
 	auto comp = GeographicLib::PolygonArea(geod, false);
 
-    struct op {
-        static double Apply(const Polygon &poly, GeographicLib::PolygonArea &comp) {
-            return PolygonPerimeter(poly, comp);
-        }
+	struct op {
+		static double Apply(const Polygon &poly, GeographicLib::PolygonArea &comp) {
+			return PolygonPerimeter(poly, comp);
+		}
 
-        static double Apply(const MultiPolygon &mpoly, GeographicLib::PolygonArea &comp) {
-            double total_perimeter = 0;
-            for (auto &poly : mpoly) {
-                total_perimeter += PolygonPerimeter(poly, comp);
-            }
-            return total_perimeter;
-        }
+		static double Apply(const MultiPolygon &mpoly, GeographicLib::PolygonArea &comp) {
+			double total_perimeter = 0;
+			for (auto &poly : mpoly) {
+				total_perimeter += PolygonPerimeter(poly, comp);
+			}
+			return total_perimeter;
+		}
 
-        static double Apply(const GeometryCollection &coll, GeographicLib::PolygonArea &comp) {
-            double total_perimeter = 0;
-            for (auto &item : coll) {
-                total_perimeter += item.Visit<op>(comp);
-            }
-            return total_perimeter;
-        }
+		static double Apply(const GeometryCollection &coll, GeographicLib::PolygonArea &comp) {
+			double total_perimeter = 0;
+			for (auto &item : coll) {
+				total_perimeter += item.Visit<op>(comp);
+			}
+			return total_perimeter;
+		}
 
-        static double Apply(const BaseGeometry &, GeographicLib::PolygonArea &) {
-            return 0.0;
-        }
-    };
+		static double Apply(const BaseGeometry &, GeographicLib::PolygonArea &) {
+			return 0.0;
+		}
+	};
 
-	UnaryExecutor::Execute<geometry_t, double>(input, result, count, [&](geometry_t input) {
-		return Geometry::Deserialize(arena, input).Visit<op>(comp);
-	});
+	UnaryExecutor::Execute<geometry_t, double>(
+	    input, result, count, [&](geometry_t input) { return Geometry::Deserialize(arena, input).Visit<op>(comp); });
 
 	if (count == 1) {
 		result.SetVectorType(VectorType::CONSTANT_VECTOR);

--- a/spatial/src/spatial/geos/functions/scalar/st_is_valid.cpp
+++ b/spatial/src/spatial/geos/functions/scalar/st_is_valid.cpp
@@ -63,7 +63,7 @@ static bool IsValidForGeos(Geometry &geometry) {
 
 static void IsValidFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GEOSFunctionLocalState::ResetAndGet(state);
-    auto &arena = lstate.arena;
+	auto &arena = lstate.arena;
 	UnaryExecutor::Execute<geometry_t, bool>(args.data[0], result, args.size(), [&](geometry_t input) {
 		auto geom = Geometry::Deserialize(arena, input);
 

--- a/spatial/src/spatial/proj/functions.cpp
+++ b/spatial/src/spatial/proj/functions.cpp
@@ -234,19 +234,19 @@ static void Point2DTransformFunction(DataChunk &args, ExpressionState &state, Ve
 
 struct TransformOp {
 	static void Apply(SinglePartGeometry &geom, PJ *crs, ArenaAllocator &arena) {
-        geom.MakeMutable(arena);
+		geom.MakeMutable(arena);
 		for (uint32_t i = 0; i < geom.Count(); i++) {
 			auto vertex = geom.Get(i);
 			auto transformed = proj_trans(crs, PJ_FWD, proj_coord(vertex.x, vertex.y, 0, 0)).xy;
 			// we own the array, so we can use SetUnsafe
-            geom.Set(i, transformed.x, transformed.y);
+			geom.Set(i, transformed.x, transformed.y);
 		}
 	}
-    static void Apply(MultiPartGeometry &geom, PJ *crs, ArenaAllocator &arena) {
-        for (auto &part : geom) {
-            part.Visit<TransformOp>(crs, arena);
-        }
-    }
+	static void Apply(MultiPartGeometry &geom, PJ *crs, ArenaAllocator &arena) {
+		for (auto &part : geom) {
+			part.Visit<TransformOp>(crs, arena);
+		}
+	}
 };
 
 struct ProjCRSDelete {


### PR DESCRIPTION
- This makes reading some formats through `ST_Read` remotely significantly faster, e.g. FlatGeoBuf.
- Fixes reading linestrings/polygons in big-endian encoded WKB, closes #288 
- Also reenable explicit usage of /vsi/ prefixes that circumvent DuckDB's filesystem.
- Also format code (which is why this diff is so huge)