### PR TITLE
Fix memory leak in st_asgeojson, avoid copy

### DIFF
--- a/spatial/src/spatial/core/functions/scalar/st_asgeojson.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_asgeojson.cpp
@@ -238,10 +238,10 @@ static void GeometryToGeoJSONFragmentFunction(DataChunk &args, ExpressionState &
 		Geometry::Match<ToGeoJSONFunctor>(geom, doc, obj);
 
 		size_t json_size = 0;
-		// TODO: YYJSON_WRITE_PRETTY
-		auto json_data = yyjson_mut_write(doc, 0, &json_size);
-		auto json_str = StringVector::AddString(result, json_data, json_size);
-		return json_str;
+		char *json_data = yyjson_mut_write_opts(doc, 0, json_allocator.GetYYJSONAllocator(), &json_size, nullptr);
+		// Because the arena allocator only resets after each pipeline invocation, we can safely just point into the
+		// arena here without needing to copy the data to the string heap with StringVector::AddString
+		return string_t(json_data, json_size);
 	});
 }
 


### PR DESCRIPTION
yyjson doesn't use the allocator set during document creation by default when using the `yyjson_mut_write` function, instead allocating the result string through malloc (causing the string to be leaked), but we now use the advanced version taking options (such as which allocator to use) to make sure the resulting string is allocated by the arena. Additionally we also avoid copying the resulting json string to the vector string heap buffer now as we can just point into the arena instead, saving some memory.

Closes #371 