### PR TITLE
Backport GDAL patch

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -231,7 +231,7 @@ ExternalProject_Add(
     DEPENDS ${GDAL_DEPENDENCIES}
     URL ${CMAKE_CURRENT_SOURCE_DIR}/vendor/gdal385.zip
     CONFIGURE_HANDLED_BY_BUILD TRUE
-    PATCH_COMMAND patch -p1 < "${CMAKE_CURRENT_LIST_DIR}/patches/remove_filehandler${PATCH_NAME_ENDING}.patch"
+    PATCH_COMMAND patch -p1 -i "${CMAKE_CURRENT_LIST_DIR}/patches/remove_filehandler${PATCH_NAME_ENDING}.patch" && patch -p1 -i "${CMAKE_CURRENT_LIST_DIR}/patches/msyspatch${PATCH_NAME_ENDING}.patch"
     CMAKE_ARGS
     # CMake options
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/deps/patches/msyspatch.patch
+++ b/deps/patches/msyspatch.patch
@@ -1,0 +1,200 @@
+diff --git a/cmake/helpers/configure.cmake b/cmake/helpers/configure.cmake
+index 989778bb7a..38973207cb 100644
+--- a/cmake/helpers/configure.cmake
++++ b/cmake/helpers/configure.cmake
+@@ -226,13 +226,13 @@ else ()
+         #endif
+         #include <sys/types.h>
+         #include <sys/stat.h>
+-        int main() { struct _stat64 buf; _wstat64( \"\", &buf ); return 0; }
++        int main() { struct _stat64 buf; wchar_t path = 0; _wstat64( &path, &buf ); return 0; }
+     "
+-    NO_UNIX_STDIO_64)
++    WINDOWS_STAT64)
+ 
+-  if (NO_UNIX_STDIO_64)
++  if (WINDOWS_STAT64)
+     set(VSI_STAT64 _stat64)
+-    set(VSI_STAT64_T __stat64)
++    set(VSI_STAT64_T _stat64)
+   endif ()
+ 
+   check_function_exists(fopen64 HAVE_FOPEN64)
+diff --git a/frmts/gtiff/libgeotiff/geotiff_proj4.c b/frmts/gtiff/libgeotiff/geotiff_proj4.c
+index 8e38120599..9d25a7c1a7 100644
+--- a/frmts/gtiff/libgeotiff/geotiff_proj4.c
++++ b/frmts/gtiff/libgeotiff/geotiff_proj4.c
+@@ -85,7 +85,7 @@ static char **OSRProj4Tokenize( const char *pszFull )
+     if( pszFull == NULL )
+         return NULL;
+ 
+-    char **papszTokens = (char **) calloc(sizeof(char*),nMaxTokens);
++    char **papszTokens = (char **) calloc(nMaxTokens, sizeof(char*));
+ 
+     char *pszFullWrk = CPLStrdup(pszFull);
+ 
+diff --git a/frmts/northwood/northwood.cpp b/frmts/northwood/northwood.cpp
+index a386df96f9..d21f00f8ab 100644
+--- a/frmts/northwood/northwood.cpp
++++ b/frmts/northwood/northwood.cpp
+@@ -184,14 +184,14 @@ int nwt_ParseHeader(NWT_GRID *pGrd, const unsigned char *nwtHeader)
+         }
+         CPL_LSBPTR16(&usTmp);
+         pGrd->stClassDict = reinterpret_cast<NWT_CLASSIFIED_DICT *>(
+-            calloc(sizeof(NWT_CLASSIFIED_DICT), 1));
++            calloc(1, sizeof(NWT_CLASSIFIED_DICT)));
+ 
+         pGrd->stClassDict->nNumClassifiedItems = usTmp;
+ 
+         pGrd->stClassDict->stClassifiedItem =
+             reinterpret_cast<NWT_CLASSIFIED_ITEM **>(
+-                calloc(sizeof(NWT_CLASSIFIED_ITEM *),
+-                       pGrd->stClassDict->nNumClassifiedItems + 1));
++                calloc(pGrd->stClassDict->nNumClassifiedItems + 1, 
++                       sizeof(NWT_CLASSIFIED_ITEM *)));
+ 
+         // load the dictionary
+         for (usTmp = 0; usTmp < pGrd->stClassDict->nNumClassifiedItems; usTmp++)
+@@ -199,7 +199,7 @@ int nwt_ParseHeader(NWT_GRID *pGrd, const unsigned char *nwtHeader)
+             NWT_CLASSIFIED_ITEM *psItem =
+                 pGrd->stClassDict->stClassifiedItem[usTmp] =
+                     reinterpret_cast<NWT_CLASSIFIED_ITEM *>(
+-                        calloc(sizeof(NWT_CLASSIFIED_ITEM), 1));
++                        calloc(1, sizeof(NWT_CLASSIFIED_ITEM)));
+ 
+             unsigned char cTmp[256];
+             if (!VSIFReadL(&cTmp, 9, 1, pGrd->fp))
+@@ -423,7 +423,7 @@ NWT_GRID *nwtOpenGrid(char *filename)
+         nwtHeader[3] != 'C')
+         return nullptr;
+ 
+-    NWT_GRID *pGrd = reinterpret_cast<NWT_GRID *>(calloc(sizeof(NWT_GRID), 1));
++    NWT_GRID *pGrd = reinterpret_cast<NWT_GRID *>(calloc(1, sizeof(NWT_GRID)));
+ 
+     if (nwtHeader[4] == '1')
+         pGrd->cFormat = 0x00;  // grd - surface type
+diff --git a/frmts/stacit/stacitdataset.cpp b/frmts/stacit/stacitdataset.cpp
+index 91ccc95c1a..eee65ade8d 100644
+--- a/frmts/stacit/stacitdataset.cpp
++++ b/frmts/stacit/stacitdataset.cpp
+@@ -288,6 +288,10 @@ static void ParseAsset(const CPLJSONObject &jAsset,
+         for (const auto &oItem : oProjTransform)
+             transform.push_back(oItem.ToDouble());
+         CPLAssert(transform.size() == 6 || transform.size() == 9);
++#if defined(__GNUC__)
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wnull-dereference"
++#endif
+         if (transform[0] <= 0 || transform[1] != 0 || transform[3] != 0 ||
+             transform[4] >= 0 ||
+             (transform.size() == 9 &&
+@@ -300,6 +304,9 @@ static void ParseAsset(const CPLJSONObject &jAsset,
+                 osAssetName.c_str());
+             return;
+         }
++#if defined(__GNUC__)
++#pragma GCC diagnostic pop
++#endif
+     }
+ 
+     if (bIsBBOXValid && bIsShapeValid)
+diff --git a/ogr/ogrsf_frmts/shape/dbfopen.c b/ogr/ogrsf_frmts/shape/dbfopen.c
+index 7b3b7a5d5c..789b665830 100644
+--- a/ogr/ogrsf_frmts/shape/dbfopen.c
++++ b/ogr/ogrsf_frmts/shape/dbfopen.c
+@@ -1937,13 +1937,13 @@ int SHPAPI_CALL DBFReorderFields(DBFHandle psDBF, int *panMap)
+     /* a simple malloc() would be enough, but calloc() helps clang static
+      * analyzer */
+     int *panFieldOffsetNew =
+-        STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
++        STATIC_CAST(int *, calloc(psDBF->nFields, sizeof(int)));
+     int *panFieldSizeNew =
+-        STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
++        STATIC_CAST(int *, calloc(psDBF->nFields, sizeof(int)));
+     int *panFieldDecimalsNew =
+-        STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
++        STATIC_CAST(int *, calloc(psDBF->nFields, sizeof(int)));
+     char *pachFieldTypeNew =
+-        STATIC_CAST(char *, calloc(sizeof(char), psDBF->nFields));
++        STATIC_CAST(char *, calloc(psDBF->nFields, sizeof(char)));
+     char *pszHeaderNew = STATIC_CAST(
+         char *, malloc(sizeof(char) * XBASE_FLDHDR_SZ * psDBF->nFields));
+ 
+diff --git a/ogr/ogrsf_frmts/shape/sbnsearch.c b/ogr/ogrsf_frmts/shape/sbnsearch.c
+index 73b573ae7a..7027057c8f 100644
+--- a/ogr/ogrsf_frmts/shape/sbnsearch.c
++++ b/ogr/ogrsf_frmts/shape/sbnsearch.c
+@@ -191,7 +191,7 @@ SBNSearchHandle SBNOpenDiskTree(const char *pszSBNFilename, SAHooks *psHooks)
+     /*      Initialize the handle structure.                                */
+     /* -------------------------------------------------------------------- */
+     SBNSearchHandle hSBN =
+-        STATIC_CAST(SBNSearchHandle, calloc(sizeof(struct SBNSearchInfo), 1));
++        STATIC_CAST(SBNSearchHandle, calloc(1, sizeof(struct SBNSearchInfo)));
+ 
+     if (psHooks == SHPLIB_NULLPTR)
+         SASetupDefaultHooks(&(hSBN->sHooks));
+diff --git a/ogr/ogrsf_frmts/shape/shpopen.c b/ogr/ogrsf_frmts/shape/shpopen.c
+index df0bd4996d..a5c7f5e057 100644
+--- a/ogr/ogrsf_frmts/shape/shpopen.c
++++ b/ogr/ogrsf_frmts/shape/shpopen.c
+@@ -363,7 +363,7 @@ SHPHandle SHPAPI_CALL SHPOpenLL(const char *pszLayer, const char *pszAccess,
+     /* -------------------------------------------------------------------- */
+     /*  Initialize the info structure.                  */
+     /* -------------------------------------------------------------------- */
+-    SHPHandle psSHP = STATIC_CAST(SHPHandle, calloc(sizeof(SHPInfo), 1));
++    SHPHandle psSHP = STATIC_CAST(SHPHandle, calloc(1, sizeof(SHPInfo)));
+ 
+     psSHP->bUpdated = FALSE;
+     memcpy(&(psSHP->sHooks), psHooks, sizeof(SAHooks));
+@@ -1174,7 +1174,7 @@ SHPHandle SHPAPI_CALL SHPCreateLL(const char *pszLayer, int nShapeType,
+         return NULL;
+     }
+ 
+-    SHPHandle psSHP = STATIC_CAST(SHPHandle, calloc(sizeof(SHPInfo), 1));
++    SHPHandle psSHP = STATIC_CAST(SHPHandle, calloc(1, sizeof(SHPInfo)));
+ 
+     psSHP->bUpdated = FALSE;
+     memcpy(&(psSHP->sHooks), psHooks, sizeof(SAHooks));
+@@ -1318,7 +1318,7 @@ SHPObject SHPAPI_CALL1(*)
+         psObject->nParts = MAX(1, nParts);
+ 
+         psObject->panPartStart =
+-            STATIC_CAST(int *, calloc(sizeof(int), psObject->nParts));
++            STATIC_CAST(int *, calloc(psObject->nParts, sizeof(int)));
+         psObject->panPartType =
+             STATIC_CAST(int *, malloc(sizeof(int) * psObject->nParts));
+ 
+@@ -1348,16 +1348,16 @@ SHPObject SHPAPI_CALL1(*)
+         const size_t nSize = sizeof(double) * nVertices;
+         psObject->padfX =
+             STATIC_CAST(double *, padfX ? malloc(nSize)
+-                                        : calloc(sizeof(double), nVertices));
++                                        : calloc(nVertices, sizeof(double)));
+         psObject->padfY =
+             STATIC_CAST(double *, padfY ? malloc(nSize)
+-                                        : calloc(sizeof(double), nVertices));
++                                        : calloc(nVertices, sizeof(double)));
+         psObject->padfZ = STATIC_CAST(
+             double *,
+-            padfZ &&bHasZ ? malloc(nSize) : calloc(sizeof(double), nVertices));
++            padfZ &&bHasZ ? malloc(nSize) : calloc(nVertices, sizeof(double)));
+         psObject->padfM = STATIC_CAST(
+             double *,
+-            padfM &&bHasM ? malloc(nSize) : calloc(sizeof(double), nVertices));
++            padfM &&bHasM ? malloc(nSize) : calloc(nVertices, sizeof(double)));
+         if (padfX != SHPLIB_NULLPTR)
+             memcpy(psObject->padfX, padfX, nSize);
+         if (padfY != SHPLIB_NULLPTR)
+diff --git a/ogr/ogrsf_frmts/shape/shptree.c b/ogr/ogrsf_frmts/shape/shptree.c
+index ed7681583e..a52f1a03b4 100644
+--- a/ogr/ogrsf_frmts/shape/shptree.c
++++ b/ogr/ogrsf_frmts/shape/shptree.c
+@@ -751,7 +751,7 @@ SHPTreeDiskHandle SHPOpenDiskTree(const char *pszQIXFilename, SAHooks *psHooks)
+     SHPTreeDiskHandle hDiskTree;
+ 
+     hDiskTree = STATIC_CAST(SHPTreeDiskHandle,
+-                            calloc(sizeof(struct SHPDiskTreeInfo), 1));
++                            calloc(1, sizeof(struct SHPDiskTreeInfo)));
+ 
+     if (psHooks == SHPLIB_NULLPTR)
+         SASetupDefaultHooks(&(hDiskTree->sHooks));

--- a/deps/patches/msyspatch_wasm.patch
+++ b/deps/patches/msyspatch_wasm.patch
@@ -1,0 +1,200 @@
+diff --git a/cmake/helpers/configure.cmake b/cmake/helpers/configure.cmake
+index 989778bb7a..38973207cb 100644
+--- a/cmake/helpers/configure.cmake
++++ b/cmake/helpers/configure.cmake
+@@ -226,13 +226,13 @@ else ()
+         #endif
+         #include <sys/types.h>
+         #include <sys/stat.h>
+-        int main() { struct _stat64 buf; _wstat64( \"\", &buf ); return 0; }
++        int main() { struct _stat64 buf; wchar_t path = 0; _wstat64( &path, &buf ); return 0; }
+     "
+-    NO_UNIX_STDIO_64)
++    WINDOWS_STAT64)
+ 
+-  if (NO_UNIX_STDIO_64)
++  if (WINDOWS_STAT64)
+     set(VSI_STAT64 _stat64)
+-    set(VSI_STAT64_T __stat64)
++    set(VSI_STAT64_T _stat64)
+   endif ()
+ 
+   check_function_exists(fopen64 HAVE_FOPEN64)
+diff --git a/frmts/gtiff/libgeotiff/geotiff_proj4.c b/frmts/gtiff/libgeotiff/geotiff_proj4.c
+index 8e38120599..9d25a7c1a7 100644
+--- a/frmts/gtiff/libgeotiff/geotiff_proj4.c
++++ b/frmts/gtiff/libgeotiff/geotiff_proj4.c
+@@ -85,7 +85,7 @@ static char **OSRProj4Tokenize( const char *pszFull )
+     if( pszFull == NULL )
+         return NULL;
+ 
+-    char **papszTokens = (char **) calloc(sizeof(char*),nMaxTokens);
++    char **papszTokens = (char **) calloc(nMaxTokens, sizeof(char*));
+ 
+     char *pszFullWrk = CPLStrdup(pszFull);
+ 
+diff --git a/frmts/northwood/northwood.cpp b/frmts/northwood/northwood.cpp
+index a386df96f9..d21f00f8ab 100644
+--- a/frmts/northwood/northwood.cpp
++++ b/frmts/northwood/northwood.cpp
+@@ -184,14 +184,14 @@ int nwt_ParseHeader(NWT_GRID *pGrd, const unsigned char *nwtHeader)
+         }
+         CPL_LSBPTR16(&usTmp);
+         pGrd->stClassDict = reinterpret_cast<NWT_CLASSIFIED_DICT *>(
+-            calloc(sizeof(NWT_CLASSIFIED_DICT), 1));
++            calloc(1, sizeof(NWT_CLASSIFIED_DICT)));
+ 
+         pGrd->stClassDict->nNumClassifiedItems = usTmp;
+ 
+         pGrd->stClassDict->stClassifiedItem =
+             reinterpret_cast<NWT_CLASSIFIED_ITEM **>(
+-                calloc(sizeof(NWT_CLASSIFIED_ITEM *),
+-                       pGrd->stClassDict->nNumClassifiedItems + 1));
++                calloc(pGrd->stClassDict->nNumClassifiedItems + 1, 
++                       sizeof(NWT_CLASSIFIED_ITEM *)));
+ 
+         // load the dictionary
+         for (usTmp = 0; usTmp < pGrd->stClassDict->nNumClassifiedItems; usTmp++)
+@@ -199,7 +199,7 @@ int nwt_ParseHeader(NWT_GRID *pGrd, const unsigned char *nwtHeader)
+             NWT_CLASSIFIED_ITEM *psItem =
+                 pGrd->stClassDict->stClassifiedItem[usTmp] =
+                     reinterpret_cast<NWT_CLASSIFIED_ITEM *>(
+-                        calloc(sizeof(NWT_CLASSIFIED_ITEM), 1));
++                        calloc(1, sizeof(NWT_CLASSIFIED_ITEM)));
+ 
+             unsigned char cTmp[256];
+             if (!VSIFReadL(&cTmp, 9, 1, pGrd->fp))
+@@ -423,7 +423,7 @@ NWT_GRID *nwtOpenGrid(char *filename)
+         nwtHeader[3] != 'C')
+         return nullptr;
+ 
+-    NWT_GRID *pGrd = reinterpret_cast<NWT_GRID *>(calloc(sizeof(NWT_GRID), 1));
++    NWT_GRID *pGrd = reinterpret_cast<NWT_GRID *>(calloc(1, sizeof(NWT_GRID)));
+ 
+     if (nwtHeader[4] == '1')
+         pGrd->cFormat = 0x00;  // grd - surface type
+diff --git a/frmts/stacit/stacitdataset.cpp b/frmts/stacit/stacitdataset.cpp
+index 91ccc95c1a..eee65ade8d 100644
+--- a/frmts/stacit/stacitdataset.cpp
++++ b/frmts/stacit/stacitdataset.cpp
+@@ -288,6 +288,10 @@ static void ParseAsset(const CPLJSONObject &jAsset,
+         for (const auto &oItem : oProjTransform)
+             transform.push_back(oItem.ToDouble());
+         CPLAssert(transform.size() == 6 || transform.size() == 9);
++#if defined(__GNUC__)
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wnull-dereference"
++#endif
+         if (transform[0] <= 0 || transform[1] != 0 || transform[3] != 0 ||
+             transform[4] >= 0 ||
+             (transform.size() == 9 &&
+@@ -300,6 +304,9 @@ static void ParseAsset(const CPLJSONObject &jAsset,
+                 osAssetName.c_str());
+             return;
+         }
++#if defined(__GNUC__)
++#pragma GCC diagnostic pop
++#endif
+     }
+ 
+     if (bIsBBOXValid && bIsShapeValid)
+diff --git a/ogr/ogrsf_frmts/shape/dbfopen.c b/ogr/ogrsf_frmts/shape/dbfopen.c
+index 7b3b7a5d5c..789b665830 100644
+--- a/ogr/ogrsf_frmts/shape/dbfopen.c
++++ b/ogr/ogrsf_frmts/shape/dbfopen.c
+@@ -1937,13 +1937,13 @@ int SHPAPI_CALL DBFReorderFields(DBFHandle psDBF, int *panMap)
+     /* a simple malloc() would be enough, but calloc() helps clang static
+      * analyzer */
+     int *panFieldOffsetNew =
+-        STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
++        STATIC_CAST(int *, calloc(psDBF->nFields, sizeof(int)));
+     int *panFieldSizeNew =
+-        STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
++        STATIC_CAST(int *, calloc(psDBF->nFields, sizeof(int)));
+     int *panFieldDecimalsNew =
+-        STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
++        STATIC_CAST(int *, calloc(psDBF->nFields, sizeof(int)));
+     char *pachFieldTypeNew =
+-        STATIC_CAST(char *, calloc(sizeof(char), psDBF->nFields));
++        STATIC_CAST(char *, calloc(psDBF->nFields, sizeof(char)));
+     char *pszHeaderNew = STATIC_CAST(
+         char *, malloc(sizeof(char) * XBASE_FLDHDR_SZ * psDBF->nFields));
+ 
+diff --git a/ogr/ogrsf_frmts/shape/sbnsearch.c b/ogr/ogrsf_frmts/shape/sbnsearch.c
+index 73b573ae7a..7027057c8f 100644
+--- a/ogr/ogrsf_frmts/shape/sbnsearch.c
++++ b/ogr/ogrsf_frmts/shape/sbnsearch.c
+@@ -191,7 +191,7 @@ SBNSearchHandle SBNOpenDiskTree(const char *pszSBNFilename, SAHooks *psHooks)
+     /*      Initialize the handle structure.                                */
+     /* -------------------------------------------------------------------- */
+     SBNSearchHandle hSBN =
+-        STATIC_CAST(SBNSearchHandle, calloc(sizeof(struct SBNSearchInfo), 1));
++        STATIC_CAST(SBNSearchHandle, calloc(1, sizeof(struct SBNSearchInfo)));
+ 
+     if (psHooks == SHPLIB_NULLPTR)
+         SASetupDefaultHooks(&(hSBN->sHooks));
+diff --git a/ogr/ogrsf_frmts/shape/shpopen.c b/ogr/ogrsf_frmts/shape/shpopen.c
+index df0bd4996d..a5c7f5e057 100644
+--- a/ogr/ogrsf_frmts/shape/shpopen.c
++++ b/ogr/ogrsf_frmts/shape/shpopen.c
+@@ -363,7 +363,7 @@ SHPHandle SHPAPI_CALL SHPOpenLL(const char *pszLayer, const char *pszAccess,
+     /* -------------------------------------------------------------------- */
+     /*  Initialize the info structure.                  */
+     /* -------------------------------------------------------------------- */
+-    SHPHandle psSHP = STATIC_CAST(SHPHandle, calloc(sizeof(SHPInfo), 1));
++    SHPHandle psSHP = STATIC_CAST(SHPHandle, calloc(1, sizeof(SHPInfo)));
+ 
+     psSHP->bUpdated = FALSE;
+     memcpy(&(psSHP->sHooks), psHooks, sizeof(SAHooks));
+@@ -1174,7 +1174,7 @@ SHPHandle SHPAPI_CALL SHPCreateLL(const char *pszLayer, int nShapeType,
+         return NULL;
+     }
+ 
+-    SHPHandle psSHP = STATIC_CAST(SHPHandle, calloc(sizeof(SHPInfo), 1));
++    SHPHandle psSHP = STATIC_CAST(SHPHandle, calloc(1, sizeof(SHPInfo)));
+ 
+     psSHP->bUpdated = FALSE;
+     memcpy(&(psSHP->sHooks), psHooks, sizeof(SAHooks));
+@@ -1318,7 +1318,7 @@ SHPObject SHPAPI_CALL1(*)
+         psObject->nParts = MAX(1, nParts);
+ 
+         psObject->panPartStart =
+-            STATIC_CAST(int *, calloc(sizeof(int), psObject->nParts));
++            STATIC_CAST(int *, calloc(psObject->nParts, sizeof(int)));
+         psObject->panPartType =
+             STATIC_CAST(int *, malloc(sizeof(int) * psObject->nParts));
+ 
+@@ -1348,16 +1348,16 @@ SHPObject SHPAPI_CALL1(*)
+         const size_t nSize = sizeof(double) * nVertices;
+         psObject->padfX =
+             STATIC_CAST(double *, padfX ? malloc(nSize)
+-                                        : calloc(sizeof(double), nVertices));
++                                        : calloc(nVertices, sizeof(double)));
+         psObject->padfY =
+             STATIC_CAST(double *, padfY ? malloc(nSize)
+-                                        : calloc(sizeof(double), nVertices));
++                                        : calloc(nVertices, sizeof(double)));
+         psObject->padfZ = STATIC_CAST(
+             double *,
+-            padfZ &&bHasZ ? malloc(nSize) : calloc(sizeof(double), nVertices));
++            padfZ &&bHasZ ? malloc(nSize) : calloc(nVertices, sizeof(double)));
+         psObject->padfM = STATIC_CAST(
+             double *,
+-            padfM &&bHasM ? malloc(nSize) : calloc(sizeof(double), nVertices));
++            padfM &&bHasM ? malloc(nSize) : calloc(nVertices, sizeof(double)));
+         if (padfX != SHPLIB_NULLPTR)
+             memcpy(psObject->padfX, padfX, nSize);
+         if (padfY != SHPLIB_NULLPTR)
+diff --git a/ogr/ogrsf_frmts/shape/shptree.c b/ogr/ogrsf_frmts/shape/shptree.c
+index ed7681583e..a52f1a03b4 100644
+--- a/ogr/ogrsf_frmts/shape/shptree.c
++++ b/ogr/ogrsf_frmts/shape/shptree.c
+@@ -751,7 +751,7 @@ SHPTreeDiskHandle SHPOpenDiskTree(const char *pszQIXFilename, SAHooks *psHooks)
+     SHPTreeDiskHandle hDiskTree;
+ 
+     hDiskTree = STATIC_CAST(SHPTreeDiskHandle,
+-                            calloc(sizeof(struct SHPDiskTreeInfo), 1));
++                            calloc(1, sizeof(struct SHPDiskTreeInfo)));
+ 
+     if (psHooks == SHPLIB_NULLPTR)
+         SASetupDefaultHooks(&(hDiskTree->sHooks));


### PR DESCRIPTION
Adds the changes in https://github.com/OSGeo/gdal/pull/9899 to the list of GDAL patches we bundle, to hopefully fix msys64 builds.