### PR TITLE
Fix `CREATE IF NOT EXISTS` for r-tree indexes, don't destroy buffers when evicted during bulk-loading.

### DIFF
--- a/spatial/include/spatial/core/util/managed_collection.hpp
+++ b/spatial/include/spatial/core/util/managed_collection.hpp
@@ -95,7 +95,7 @@ void ManagedCollection<T>::InitializeAppend(ManagedCollectionAppendState &state,
 		state.block = &blocks.back();
 		state.block->item_count = 0;
 		state.block->item_capacity = block_capacity;
-		state.handle = manager.Allocate(MemoryTag::EXTENSION, block_size, true);
+		state.handle = manager.Allocate(MemoryTag::EXTENSION, block_size, false);
 		state.block->handle = state.handle.GetBlockHandle();
 	}
 }
@@ -109,7 +109,7 @@ void ManagedCollection<T>::Append(ManagedCollectionAppendState &state, const T *
 			state.block = &blocks.back();
 			state.block->item_count = 0;
 			state.block->item_capacity = block_capacity;
-			state.handle = manager.Allocate(MemoryTag::EXTENSION, block_size, true);
+			state.handle = manager.Allocate(MemoryTag::EXTENSION, block_size, false);
 			state.block->handle = state.handle.GetBlockHandle();
 		}
 

--- a/spatial/src/spatial/core/index/rtree/rtree_index_create_physical.cpp
+++ b/spatial/src/spatial/core/index/rtree/rtree_index_create_physical.cpp
@@ -290,6 +290,9 @@ static void AddIndexToCatalog(ClientContext &context, CreateRTreeIndexGlobalStat
 		if (info.on_conflict != OnCreateConflict::IGNORE_ON_CONFLICT) {
 			throw CatalogException("Index with name \"%s\" already exists", info.index_name);
 		}
+		// IF NOT EXISTS on existing index. We are done.
+		// TODO: Early out before this.
+		return;
 	}
 
 	const auto index_entry = schema.CreateIndex(schema.GetCatalogTransaction(context), info, table).get();

--- a/test/sql/index/rtree_conflict.test
+++ b/test/sql/index/rtree_conflict.test
@@ -1,0 +1,18 @@
+require spatial
+
+statement ok
+create table nodes (name varchar, pt geometry);
+
+statement ok
+create index if not exists nodes_pt_idx on nodes using rtree(pt);
+
+statement ok
+create index if not exists nodes_pt_idx on nodes using rtree(pt);
+
+statement error
+create index nodes_pt_idx on nodes using rtree(pt);
+----
+Catalog Error: Index with name "nodes_pt_idx" already exists
+
+statement ok
+create index if not exists nodes_pt_idx on nodes using rtree(pt);


### PR DESCRIPTION
Closes #410 
Closes #417