### PR TITLE
Only check external access flag on raw GDAL vis handlers, disable filter pushdown in st_read

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,9 @@ EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
+
+#### Override the included format target because we have different source tree layout
+format:
+	find spatial/src -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i
+	find spatial/include -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i
+	cmake-format -i CMakeLists.txt

--- a/spatial/include/spatial/gdal/file_handler.hpp
+++ b/spatial/include/spatial/gdal/file_handler.hpp
@@ -10,6 +10,7 @@ namespace gdal {
 class DuckDBFileSystemHandler;
 
 class GDALClientContextState : public ClientContextState {
+	ClientContext &context;
 	string client_prefix;
 	DuckDBFileSystemHandler *fs_handler;
 

--- a/spatial/src/spatial/core/io/osm/st_read_osm.cpp
+++ b/spatial/src/spatial/core/io/osm/st_read_osm.cpp
@@ -84,11 +84,6 @@ static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindIn
 	names.push_back("ref_types");
 
 	// Create bind data
-	auto &config = DBConfig::GetConfig(context);
-	if (!config.options.enable_external_access) {
-		throw PermissionException("Scanning OSM files is disabled through configuration");
-	}
-
 	auto file_name = StringValue::Get(input.inputs[0]);
 	auto result = make_uniq<BindData>(file_name);
 	return std::move(result);

--- a/test/sql/gdal/gdal_vsi.test
+++ b/test/sql/gdal/gdal_vsi.test
@@ -5,3 +5,14 @@ query I
 SELECT COUNT(*) FROM st_read('/vsigzip/__WORKING_DIRECTORY__/test/data/amsterdam_roads_50.geojson.gz');
 ----
 50
+
+
+# Disable external access
+statement ok
+set enable_external_access = false;
+
+# Test read via VSI
+statement error
+SELECT COUNT(*) FROM st_read('/vsigzip/__WORKING_DIRECTORY__/test/data/amsterdam_roads_50.geojson.gz');
+----
+with VSI prefix: External access is disabled


### PR DESCRIPTION
This PR make two changes related to how we interface with GDAL.

1. Given the changes in https://github.com/duckdb/duckdb/pull/14568 we no longer explicitly check if external access is disabled in the `st_read/st_read_meta/st_read_osm` functions as that is now handled by the DuckDB filesystem. However, if a user supplies a `/vsi/`-prefixed path to circumvent the DuckDB filesystem handler we check the external access flag explicitly, but don't consider any additional whitelisted paths or directories. This should fix #461 

2. We no longer push down filters into GDAL when using st_read. This was never tested properly and since we don't really support any remote drivers (like pgsql/mysql) where filter pushdown make sense, id expect the performance benefits to be negligible. In some cases it may even be more efficient to allow duckdb to execute the filters, as we discovered in the case of sqlite and DuckDBs sqlite_scanner extension. This should fix #457 

