### PR TITLE
Make `sgl::geometry` non-copyable/moveable

### DIFF
--- a/src/sgl/sgl.cpp
+++ b/src/sgl/sgl.cpp
@@ -75,20 +75,22 @@ bool interpolate(const sgl::geometry *geom, double frac, vertex_xyzm *out) {
 	return false;
 }
 
-sgl::geometry interpolate_points(sgl::allocator *alloc, const sgl::geometry *geom, double frac) {
+void interpolate_points(sgl::geometry *result, sgl::allocator *alloc, const sgl::geometry *geom, double frac) {
 
 	SGL_ASSERT(geom);
 	if(geom->get_type() != sgl::geometry_type::LINESTRING) {
-		return point::make_empty(geom->has_z(), geom->has_m());
+		point::init_empty(result, geom->has_z(), geom->has_m());
+		return;
 	}
 	if(geom->is_empty()) {
-		return point::make_empty(geom->has_z(), geom->has_m());
+		point::init_empty(result, geom->has_z(), geom->has_m());
+		return;
 	}
 
 	if(geom->get_count() == 1) {
-		auto point = point::make_empty(geom->has_z(), geom->has_m());
-		point.set_vertex_data(geom->get_vertex_data(), 1);
-		return point;
+		point::init_empty(result, geom->has_z(), geom->has_m());
+		result->set_vertex_data(geom->get_vertex_data(), 1);
+		return;
 	}
 
 	// Clamp the fraction to [0, 1]
@@ -100,17 +102,20 @@ sgl::geometry interpolate_points(sgl::allocator *alloc, const sgl::geometry *geo
 
 	// Special cases
 	if(frac == 0) {
-		auto point = point::make_empty(geom->has_z(), geom->has_m());
-		point.set_vertex_data(vertex_data, 1);
+		point::init_empty(result, geom->has_z(), geom->has_m());
+		result->set_vertex_data(vertex_data, 1);
+		return;
 	}
 
 	if(frac == 1) {
-		auto point = point::make_empty(geom->has_z(), geom->has_m());
-		point.set_vertex_data(vertex_data + (vertex_count - 1) * vertex_stride, 1);
+		point::init_empty(result, geom->has_z(), geom->has_m());
+		result->set_vertex_data(vertex_data + (vertex_count - 1) * vertex_stride, 1);
+		return;
 	}
 
 
-	auto mpoint = multi_point::make_empty(geom->has_z(), geom->has_m());
+	// Make a multi-point
+	multi_point::init_empty(result, geom->has_z(), geom->has_m());
 
 	const auto actual_length = linestring::length(geom);
 	double total_length = 0.0;
@@ -151,7 +156,7 @@ sgl::geometry interpolate_points(sgl::allocator *alloc, const sgl::geometry *geo
 
 			// Set the vertex data and append it to the multi-point
 			point_ptr->set_vertex_data(data_mem, 1);
-			mpoint.append_part(point_ptr);
+			result->append_part(point_ptr);
 
 			// Update the target length
 			next_target += frac * actual_length;
@@ -159,24 +164,23 @@ sgl::geometry interpolate_points(sgl::allocator *alloc, const sgl::geometry *geo
 		total_length += segment_length;
 		prev = next;
 	}
-
-	return mpoint;
 }
 
-sgl::geometry substring(sgl::allocator *alloc, const sgl::geometry *geom, double beg_frac, double end_frac) {
-	auto line = linestring::make_empty(geom->has_z(), geom->has_m());
+void substring(sgl::geometry *line, sgl::allocator *alloc, const sgl::geometry *geom, double beg_frac, double end_frac) {
+	linestring::init_empty(line, geom->has_z(), geom->has_m());
+
 	if(geom->get_type() != sgl::geometry_type::LINESTRING) {
-		return line;
+		return;
 	}
 	if(geom->is_empty()) {
 		if(beg_frac == end_frac) {
-			line.set_type(geometry_type::POINT);
+			line->set_type(geometry_type::POINT);
 		}
-		return line;
+		return;
 	}
 
 	if(beg_frac > end_frac) {
-		return line;
+		return;
 	}
 
 	beg_frac = std::min(std::max(beg_frac, 0.0), 1.0);
@@ -188,8 +192,8 @@ sgl::geometry substring(sgl::allocator *alloc, const sgl::geometry *geom, double
 
 	// Reference the whole line
 	if(beg_frac == 0 && end_frac == 1) {
-		line.set_vertex_data(vertex_data, vertex_count);
-		return line;
+		line->set_vertex_data(vertex_data, vertex_count);
+		return;
 	}
 
 	if(beg_frac == end_frac) {
@@ -197,15 +201,15 @@ sgl::geometry substring(sgl::allocator *alloc, const sgl::geometry *geom, double
 		vertex_xyzm point = {};
 
 		// Make it a point instead!
-		line.set_type(geometry_type::POINT);
+		line->set_type(geometry_type::POINT);
 
 		if(interpolate(geom, beg_frac, &point)) {
 			const auto mem = static_cast<char *>(alloc->alloc(vertex_size));
 			memcpy(mem, &point, vertex_size);
-			line.set_vertex_data(mem, 1);
+			line->set_vertex_data(mem, 1);
 		}
 
-		return line;
+		return;
 	}
 
 	vertex_xyzm beg = {};
@@ -281,8 +285,7 @@ sgl::geometry substring(sgl::allocator *alloc, const sgl::geometry *geom, double
 	// Copy the end point
 	memcpy(new_vertex_data + (new_vertex_count - 1) * vertex_size, &end, vertex_size);
 
-	line.set_vertex_data(new_vertex_data, new_vertex_count);
-	return line;
+	line->set_vertex_data(new_vertex_data, new_vertex_count);
 }
 
 
@@ -1829,22 +1832,19 @@ static void handle_polygons(void *state, sgl::geometry *geom) {
 	}
 }
 
-geometry extract_points(sgl::geometry *geom) {
-	auto points = sgl::geometry(sgl::geometry_type::MULTI_POINT, geom->has_z(), geom->has_m());
-	geom->filter_parts(&points, select_points, handle_points);
-	return points;
+void extract_points(sgl::geometry *result, sgl::geometry *geom) {
+	multi_point::init_empty(result, geom->has_z(), geom->has_m());
+	geom->filter_parts(result, select_points, handle_points);
 }
 
-geometry extract_linestrings(sgl::geometry *geom) {
-	auto lines = sgl::geometry(sgl::geometry_type::MULTI_LINESTRING, geom->has_z(), geom->has_m());
-	geom->filter_parts(&lines, select_lines, handle_lines);
-	return lines;
+void extract_linestrings(sgl::geometry *result, sgl::geometry *geom) {
+	multi_linestring::init_empty(result, geom->has_z(), geom->has_m());
+	geom->filter_parts(result, select_lines, handle_lines);
 }
 
-geometry extract_polygons(sgl::geometry *geom) {
-	auto polygons = sgl::geometry(sgl::geometry_type::MULTI_POLYGON, geom->has_z(), geom->has_m());
-	geom->filter_parts(&polygons, select_polygons, handle_polygons);
-	return polygons;
+void extract_polygons(sgl::geometry *result, sgl::geometry *geom) {
+	multi_polygon::init_empty(result, geom->has_z(), geom->has_m());
+	geom->filter_parts(result, select_polygons, handle_polygons);
 }
 
 

--- a/src/spatial/modules/geos/geos_module.cpp
+++ b/src/spatial/modules/geos/geos_module.cpp
@@ -439,12 +439,12 @@ struct ST_ConcaveHull {
 		const auto &lstate = LocalState::ResetAndGet(state);
 
 		TernaryExecutor::Execute<string_t, double, bool, string_t>(
-		    	args.data[0],args.data[1],args.data[2], result, args.size(),
-		    	[&](const string_t &geom_blob, const double ratio, const bool  allowHoles) {
-			const auto geom = lstate.Deserialize(geom_blob);
-			const auto hull = geom.get_concave_hull(ratio, allowHoles);
-			return lstate.Serialize(result, hull);
-		});
+		    args.data[0], args.data[1], args.data[2], result, args.size(),
+		    [&](const string_t &geom_blob, const double ratio, const bool allowHoles) {
+			    const auto geom = lstate.Deserialize(geom_blob);
+			    const auto hull = geom.get_concave_hull(ratio, allowHoles);
+			    return lstate.Serialize(result, hull);
+		    });
 	}
 
 	static void Register(DatabaseInstance &db) {
@@ -459,7 +459,11 @@ struct ST_ConcaveHull {
 				variant.SetFunction(Execute);
 			});
 
-			func.SetDescription("Returns the 'concave' hull of the input geometry, containing all of the source input's points, and which can be used to create polygons from points. The ratio parameter dictates the level of concavity; 1.0 returns the convex hull; and 0 indicates to return the most concave hull possible. Set allowHoles to a non-zero value to allow output containing holes.");
+			func.SetDescription(
+			    "Returns the 'concave' hull of the input geometry, containing all of the source input's points, and "
+			    "which can be used to create polygons from points. The ratio parameter dictates the level of "
+			    "concavity; 1.0 returns the convex hull; and 0 indicates to return the most concave hull possible. Set "
+			    "allowHoles to a non-zero value to allow output containing holes.");
 			func.SetTag("ext", "spatial");
 			func.SetTag("category", "construction");
 		});
@@ -1022,7 +1026,7 @@ struct ST_MinimumRotatedRectangle {
 	static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
 		const auto &lstate = LocalState::ResetAndGet(state);
 
-		UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](const string_t &geom_blob ) {
+		UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](const string_t &geom_blob) {
 			const auto geom = lstate.Deserialize(geom_blob);
 			const auto mrr = geom.get_minimum_rotated_rectangle();
 			return lstate.Serialize(result, mrr);
@@ -1039,7 +1043,9 @@ struct ST_MinimumRotatedRectangle {
 				variant.SetFunction(Execute);
 			});
 
-			func.SetDescription("Returns the minimum rotated rectangle that bounds the input geometry, finding the surrounding box that has the lowest area by using a rotated rectangle, rather than taking the lowest and highest coordinate values as per ST_Envelope().");
+			func.SetDescription("Returns the minimum rotated rectangle that bounds the input geometry, finding the "
+			                    "surrounding box that has the lowest area by using a rotated rectangle, rather than "
+			                    "taking the lowest and highest coordinate values as per ST_Envelope().");
 			func.SetTag("ext", "spatial");
 			func.SetTag("category", "construction");
 		});
@@ -1378,7 +1384,7 @@ struct ST_VoronoiDiagram {
 	static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
 		const auto &lstate = LocalState::ResetAndGet(state);
 
-		UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](const string_t &geom_blob ) {
+		UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](const string_t &geom_blob) {
 			const auto geom = lstate.Deserialize(geom_blob);
 			const auto mrr = geom.get_voronoi_diagram();
 			return lstate.Serialize(result, mrr);

--- a/src/spatial/modules/main/spatial_functions_aggregate.cpp
+++ b/src/spatial/modules/main/spatial_functions_aggregate.cpp
@@ -90,10 +90,10 @@ struct ExtentAggFunction {
 			buf[8] = state.xmin;
 			buf[9] = state.ymin;
 
-			auto ring = sgl::linestring::make_empty();
+			sgl::geometry ring(sgl::geometry_type::LINESTRING, false, false);
 			ring.set_vertex_data(reinterpret_cast<const char *>(buf), 5);
 
-			auto bbox = sgl::polygon::make_empty();
+			sgl::geometry bbox(sgl::geometry_type::POLYGON, false, false);
 			bbox.append_part(&ring);
 
 			const auto size = Serde::GetRequiredSize(bbox);

--- a/src/spatial/spatial_optimizers.cpp
+++ b/src/spatial/spatial_optimizers.cpp
@@ -210,8 +210,8 @@ public:
 
 				vector<unique_ptr<Expression>> right_extent_args;
 				right_extent_args.push_back(right_pred_expr->Copy());
-				auto right_extent = make_uniq<BoundFunctionExpression>(GeoTypes::BOX_2DF(), std::move(extent_func_right),
-				                                                       std::move(right_extent_args), nullptr);
+				auto right_extent = make_uniq<BoundFunctionExpression>(
+				    GeoTypes::BOX_2DF(), std::move(extent_func_right), std::move(right_extent_args), nullptr);
 
 				// Left
 				vector<unique_ptr<Expression>> left_xmin_args;


### PR DESCRIPTION
Followup to #512 

This was an oversight on my part, because sgl geometries contain parent/sibling pointers you can't always construct geometries recursively bottom-up and still return by value without accidentally invalidating these pointers. This mostly worked previously due to RVO but that's not guaranteed in C++11 (even if most compilers do it). Therefore, to avoid more accidents in the future the safest options is to simply forbid move/copy construction and force the caller to explicitly allocate space for the return value. 