### PR TITLE
feat: implement ST_Expand

### DIFF
--- a/test/sql/geometry/st_expand.test
+++ b/test/sql/geometry/st_expand.test
@@ -1,0 +1,46 @@
+require spatial
+
+query I
+SELECT ST_AsText(ST_Expand(ST_MakePoint(153.0, -38.0), 0.001));
+----
+POLYGON ((152.999 -38.001, 152.999 -37.999, 153.001 -37.999, 153.001 -38.001, 152.999 -38.001))
+
+query I
+SELECT ST_AsText(ST_Expand(ST_MakePoint(153.0, -38.0), 0.0));
+----
+POLYGON ((153 -38, 153 -38, 153 -38, 153 -38, 153 -38))
+
+query I
+SELECT ST_AsText(ST_Expand(ST_GeomFromText('POINT(20 30)'), 0.001));
+----
+POLYGON ((19.999 29.999, 19.999 30.001, 20.001 30.001, 20.001 29.999, 19.999 29.999))
+
+query I
+SELECT ST_AsText(ST_Expand(ST_GeomFromText('GEOMETRYCOLLECTION(POINT(20 30))'), 0.001));
+----
+POLYGON ((19.999 29.999, 19.999 30.001, 20.001 30.001, 20.001 29.999, 19.999 29.999))
+
+query I
+SELECT ST_AsText(ST_Expand(ST_GeomFromText('POLYGON((20 30, 21 30, 21 31, 20 31, 20 30))'), 0.1));
+----
+POLYGON ((19.9 29.9, 19.9 31.1, 21.1 31.1, 21.1 29.9, 19.9 29.9))
+
+query I
+SELECT ST_AsText(ST_Expand(ST_GeomFromText('POLYGON((20 30, 21 30, 22 32, 21 31, 20 31, 20 30))'), 0.1));
+----
+POLYGON ((19.9 29.9, 19.9 32.1, 22.1 32.1, 22.1 29.9, 19.9 29.9))
+
+query I
+SELECT ST_AsText(ST_Expand(ST_MakeEnvelope(20, 30, 21, 31), 0.1));
+----
+POLYGON ((19.9 29.9, 19.9 31.1, 21.1 31.1, 21.1 29.9, 19.9 29.9))
+
+query I
+SELECT ST_AsText(ST_Expand(ST_MakeEnvelope(153.2, -38.8, 153.5, -38.7), 0.0));
+----
+POLYGON ((153.2 -38.8, 153.2 -38.7, 153.5 -38.7, 153.5 -38.8, 153.2 -38.8))
+
+query I
+SELECT ST_AsText(ST_Expand(ST_GeomFromText('GEOMETRYCOLLECTION EMPTY'), 0.001));
+----
+GEOMETRYCOLLECTION EMPTY


### PR DESCRIPTION
It returns a bounding polygon expanded by a specified amount. A common use case is doing a "near" search on a point.

This is a postgis function, not found by me in OGC MM.

See https://postgis.net/docs/ST_Expand.html