### PR TITLE
fix invalid geometries in ST_AsMVTGeom

### DIFF
--- a/src/spatial/modules/geos/geos_geometry.hpp
+++ b/src/spatial/modules/geos/geos_geometry.hpp
@@ -369,7 +369,7 @@ inline GeosGeometry GeosGeometry::get_transformed(const double matrix[6]) const 
 }
 
 inline GeosGeometry GeosGeometry::get_gridded(double grid_size) const {
-	return GeosGeometry(handle, GEOSGeom_setPrecision_r(handle, geom, grid_size, GEOS_PREC_NO_TOPO));
+	return GeosGeometry(handle, GEOSGeom_setPrecision_r(handle, geom, grid_size, GEOS_PREC_VALID_OUTPUT));
 }
 
 inline GeosGeometry GeosGeometry::get_maximum_inscribed_circle() const {


### PR DESCRIPTION
Changes GEOS_PREC_NO_TOPO to GEOS_PREC_VALID_OUTPUT in get_gridded() to ensure topological validity during grid snapping operations.

The current ST_AsMVTGeom sometimes produces invalid geometries because the topology is not preserved.

<img width="323" height="537" alt="Screenshot 2025-10-23 at 09 32 31" src="https://github.com/user-attachments/assets/15835509-2af2-442f-a11b-ec39d01312ca" />
<img width="396" height="541" alt="Screenshot 2025-10-23 at 09 32 28" src="https://github.com/user-attachments/assets/20e08c99-e743-4c81-96ea-0c9dce0a07ad" />
