### PR TITLE
Patch GDAL to fix windows_arm64 builds

### DIFF
--- a/vcpkg_ports/gdal/duckdb_gdal_windows_static.patch
+++ b/vcpkg_ports/gdal/duckdb_gdal_windows_static.patch
@@ -1,0 +1,14 @@
+--- a/gdal.cmake
++++ b/gdal.cmake
+@@ -619,8 +619,10 @@
+ if (MSVC)
+   target_sources(${GDAL_LIB_TARGET_NAME} PRIVATE gcore/Version.rc)
+   source_group("Resource Files" FILES gcore/Version.rc)
+-  if (CMAKE_CL_64)
++  if (CMAKE_SYSTEM_PROCESSOR STREQUAL AMD64)
+     set_target_properties(${GDAL_LIB_TARGET_NAME} PROPERTIES STATIC_LIBRARY_FLAGS "/machine:x64")
++  elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL ARM64)
++    set_target_properties(${GDAL_LIB_TARGET_NAME} PROPERTIES STATIC_LIBRARY_FLAGS "/machine:arm64")
+   endif ()
+ endif ()
+ 

--- a/vcpkg_ports/gdal/portfile.cmake
+++ b/vcpkg_ports/gdal/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         duckdb_gdal_json.patch
         duckdb_gdal_msys.patch
         duckdb_gdal_remove_filehandler.patch
+        duckdb_gdal_windows_static.patch
 )
 # `vcpkg clean` stumbles over one subdir
 file(REMOVE_RECURSE "${SOURCE_PATH}/autotest")


### PR DESCRIPTION
GDAL dependency was adding `/machine:x64` linker flag for all 64-bit platforms. On ARM64 this causes linking errors like this:

> fatal error LNK1112: module machine type 'ARM64' conflicts with target machine type 'x64'

The added patch checks for `ARM64` and `AMD64` arches before setting correct linker arg.

Ref: duckdblabs/duckdb-internal#5891