### PR TITLE
fix ring orientation for ST_AsMVTGeom and add orientation tests

### DIFF
--- a/src/spatial/modules/geos/geos_module.cpp
+++ b/src/spatial/modules/geos/geos_module.cpp
@@ -366,7 +366,7 @@ struct ST_AsMVTGeom {
 			if (!bind_data.clip) {
 
 				// But first orient in place
-				snapped.orient_polygons(true);
+				snapped.orient_polygons(false);
 
 				res_data[out_idx] = lstate.Serialize(result, snapped);
 				continue;
@@ -389,7 +389,7 @@ struct ST_AsMVTGeom {
 			auto cleaned_clipped = clipped.get_gridded(1.0);
 
 			// Also orient the polygons in place
-			cleaned_clipped.orient_polygons(true);
+			cleaned_clipped.orient_polygons(false);
 
 			res_data[out_idx] = lstate.Serialize(result, cleaned_clipped);
 		}

--- a/test/sql/mvt/st_asmvtgeom.test
+++ b/test/sql/mvt/st_asmvtgeom.test
@@ -1,0 +1,51 @@
+# name: test/sql/mvt/st_asmvtgeom.test
+# description: Test that ST_AsMVTGeom produces correct ring orientation according to MVT spec
+# group: [mvt]
+
+require spatial
+
+# Verify that ST_AsMVTGeom produces CW exterior rings in tile coordinates
+# 
+# Input: CCW Polygon in geographic coordinates (Y-up)
+# Expected: CW Polygon in tile coordinates (Y-down)
+# MVT Spec: "Exterior rings must be oriented clockwise [...] (when viewed in screen coordinates)"
+query I
+SELECT ST_AsText(
+    ST_AsMVTGeom(
+        ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'),
+        ST_Extent(ST_GeomFromText('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))')),
+        4096
+    )
+);
+----
+POLYGON ((2048 4096, 0 4096, 0 2048, 2048 2048, 2048 4096))
+
+# Verify Polygon with holes
+# 
+# Input: Polygon with CCW exterior and CW hole in geographic coordinates (Y-up)
+# Expected: Exterior is CW in screen coords (Y-down), interior is CCW (per MVT spec)
+query I
+SELECT ST_AsText(
+    ST_AsMVTGeom(
+        ST_GeomFromText('POLYGON((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 3 1, 3 3, 1 3, 1 1))'),
+        ST_Extent(ST_GeomFromText('POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))')),
+        4096
+    )
+);
+----
+POLYGON ((4096 4096, 0 4096, 0 0, 4096 0, 4096 4096), (1024 1024, 1024 3072, 3072 3072, 3072 1024, 1024 1024))
+
+# Verify Multi-Polygon
+#
+# Input: Two CCW polygons in geographic coordinates (Y-up)
+# Expected: Both polygons are CW in screen coords (Y-down)
+query I
+SELECT ST_AsText(
+    ST_AsMVTGeom(
+        ST_GeomFromText('MULTIPOLYGON(((0 0, 1 0, 1 1, 0 1, 0 0)), ((2 2, 3 2, 3 3, 2 3, 2 2)))'),
+        ST_Extent(ST_GeomFromText('POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))')),
+        4096
+    )
+);
+----
+MULTIPOLYGON (((1024 4096, 0 4096, 0 3072, 1024 3072, 1024 4096)), ((3072 2048, 2048 2048, 2048 1024, 3072 1024, 3072 2048)))


### PR DESCRIPTION
Switched `ST_AsMVTGeom` to orient polygons the right way after the Y‑flip, so exterior rings are CW and holes are CCW in tile coords (as per the MVT spec). Added tests covering a polygon, a polygon with a hole, and a multipolygon to lock this in.

Example:
```sql
D SELECT ST_AsText(
      ST_AsMVTGeom(
          ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'),
          ST_Extent(ST_GeomFromText('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))')),
          4096
      )
  );
┌──────────────────────────────────────────────────────────────────────────────────────────┐
│ st_astext(st_asmvtgeom(st_geomfromtext('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'), st_exten…  │
│                                         varchar                                          │
├──────────────────────────────────────────────────────────────────────────────────────────┤
│ POLYGON ((2048 4096, 0 4096, 0 2048, 2048 2048, 2048 4096))                              │
└──────────────────────────────────────────────────────────────────────────────────────────┘
```

Closes #731 