### PR TITLE
Mark scalar/aggregate functions that can throw errors, throw on invalid HEXWKB, update DuckDB

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -27,7 +27,7 @@ jobs:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
-      duckdb_version: v1.4.1
+      duckdb_version: v1.4.3
       extension_name: spatial
       ci_tools_version: main
       vcpkg_commit: ce613c41372b23b1f51333815feb3edd87ef8a8b
@@ -38,7 +38,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@main
     secrets: inherit
     with:
-      duckdb_version: v1.4.1
+      duckdb_version: v1.4.3
       ci_tools_version: main
       extension_name: spatial
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -14,3 +14,5 @@ duckdb_extension_load(spatial
         INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/src/spatial
         ${DO_TESTS}
 )
+
+duckdb_extension_load(json)

--- a/src/spatial/modules/geos/geos_module.cpp
+++ b/src/spatial/modules/geos/geos_module.cpp
@@ -407,6 +407,7 @@ struct ST_AsMVTGeom {
 				variant.AddParameter("buffer", LogicalType::BIGINT);
 				variant.AddParameter("clip_geom", LogicalType::BOOLEAN);
 				variant.SetReturnType(GeoTypes::GEOMETRY());
+				variant.CanThrowErrors();
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
@@ -418,6 +419,7 @@ struct ST_AsMVTGeom {
 				variant.AddParameter("extent", LogicalType::BIGINT);
 				variant.AddParameter("buffer", LogicalType::BIGINT);
 				variant.SetReturnType(GeoTypes::GEOMETRY());
+				variant.CanThrowErrors();
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
@@ -428,6 +430,7 @@ struct ST_AsMVTGeom {
 				variant.AddParameter("bounds", GeoTypes::BOX_2D());
 				variant.AddParameter("extent", LogicalType::BIGINT);
 				variant.SetReturnType(GeoTypes::GEOMETRY());
+				variant.CanThrowErrors();
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
@@ -437,6 +440,7 @@ struct ST_AsMVTGeom {
 				variant.AddParameter("geom", GeoTypes::GEOMETRY());
 				variant.AddParameter("bounds", GeoTypes::BOX_2D());
 				variant.SetReturnType(GeoTypes::GEOMETRY());
+				variant.CanThrowErrors();
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
@@ -479,6 +483,7 @@ struct ST_Boundary {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns the \"boundary\" of a geometry");
@@ -578,6 +583,7 @@ struct ST_Buffer {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
@@ -588,6 +594,7 @@ struct ST_Buffer {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteWithSegments);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
@@ -601,6 +608,7 @@ struct ST_Buffer {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteWithStyle);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -636,6 +644,7 @@ struct ST_BuildArea {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -662,6 +671,7 @@ struct ST_Contains : AsymmetricPreparedBinaryFunction<ST_Contains> {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(R"(
@@ -696,6 +706,7 @@ struct ST_ContainsProperly : AsymmetricPreparedBinaryFunction<ST_ContainsProperl
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(R"(
@@ -730,6 +741,7 @@ struct ST_WithinProperly : AsymmetricPreparedBinaryFunction<ST_WithinProperly> {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(R"(
@@ -766,6 +778,7 @@ struct ST_ConcaveHull {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(
@@ -798,6 +811,7 @@ struct ST_ConvexHull {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns the convex hull enclosing the geometry");
@@ -877,6 +891,7 @@ struct ST_CoverageInvalidEdges {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
@@ -886,6 +901,7 @@ struct ST_CoverageInvalidEdges {
 				variant.SetInit(LocalState::Init);
 				variant.SetBind(Bind);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(R"(
@@ -963,6 +979,7 @@ struct ST_CoverageSimplify {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
@@ -973,6 +990,7 @@ struct ST_CoverageSimplify {
 				variant.SetInit(LocalState::Init);
 				variant.SetBind(Bind);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(R"(
@@ -1037,6 +1055,7 @@ struct ST_CoverageUnion {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(R"(
@@ -1065,6 +1084,7 @@ struct ST_CoveredBy : AsymmetricPreparedBinaryFunction<ST_CoveredBy> {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns true if geom1 is \"covered by\" geom2");
@@ -1090,6 +1110,7 @@ struct ST_Covers : AsymmetricPreparedBinaryFunction<ST_Covers> {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns true if the geom1 \"covers\" geom2");
@@ -1115,6 +1136,7 @@ struct ST_Crosses : SymmetricPreparedBinaryFunction<ST_Crosses> {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns true if geom1 \"crosses\" geom2");
@@ -1146,6 +1168,7 @@ struct ST_Difference {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns the \"difference\" between two geometries");
@@ -1171,6 +1194,7 @@ struct ST_Disjoint : SymmetricPreparedBinaryFunction<ST_Disjoint> {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns true if the geometries are disjoint");
@@ -1196,6 +1220,7 @@ struct ST_Distance : SymmetricPreparedBinaryFunction<ST_Distance, double> {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns the planar distance between two geometries");
@@ -1287,6 +1312,7 @@ struct ST_DistanceWithin {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(R"(
@@ -1319,6 +1345,7 @@ struct ST_Equals {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns true if the geometries are \"equal\"");
@@ -1347,6 +1374,7 @@ struct ST_Envelope {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns the minimum bounding rectangle of a geometry as a polygon geometry");
@@ -1378,6 +1406,7 @@ struct ST_Intersection {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns the intersection of two geometries");
@@ -1405,6 +1434,7 @@ struct ST_Intersects : SymmetricPreparedBinaryFunction<ST_Intersects> {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns true if the geometries intersect");
@@ -1431,6 +1461,7 @@ struct ST_IsRing {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns true if the geometry is a ring (both ST_IsClosed and ST_IsSimple).");
@@ -1457,6 +1488,7 @@ struct ST_IsSimple {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns true if the geometry is simple");
@@ -1489,6 +1521,7 @@ struct ST_IsValid {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns true if the geometry is valid");
@@ -1528,6 +1561,7 @@ struct ST_LineMerge {
 				variant.SetReturnType(GeoTypes::GEOMETRY());
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
@@ -1536,6 +1570,7 @@ struct ST_LineMerge {
 				variant.SetReturnType(GeoTypes::GEOMETRY());
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteWithDirection);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(R"("Merges" the input line geometry, optionally taking direction into account.)");
@@ -1564,6 +1599,7 @@ struct ST_MakeValid {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns a valid representation of the geometry");
@@ -1644,6 +1680,7 @@ struct ST_MaximumInscribedCircle {
 				variant.SetReturnType(result_type);
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([&](ScalarFunctionVariantBuilder &variant) {
@@ -1652,6 +1689,7 @@ struct ST_MaximumInscribedCircle {
 				variant.SetReturnType(result_type);
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteWithTolerance);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(R"(
@@ -1695,6 +1733,7 @@ struct ST_MinimumRotatedRectangle {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns the minimum rotated rectangle that bounds the input geometry, finding the "
@@ -1737,6 +1776,7 @@ struct ST_Node {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -1764,6 +1804,7 @@ struct ST_Normalize {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns the \"normalized\" representation of the geometry");
@@ -1790,6 +1831,7 @@ struct ST_Overlaps : SymmetricPreparedBinaryFunction<ST_Overlaps> {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns true if the geometries overlap");
@@ -1818,6 +1860,7 @@ struct ST_PointOnSurface {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns a point guaranteed to lie on the surface of the geometry");
@@ -1877,6 +1920,7 @@ struct ST_Polygonize {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns a polygonized representation of the input geometries");
@@ -1915,6 +1959,7 @@ struct ST_ReducePrecision {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns the geometry with all vertices reduced to the given precision");
@@ -1954,6 +1999,7 @@ struct ST_RemoveRepeatedPoints {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
@@ -1963,6 +2009,7 @@ struct ST_RemoveRepeatedPoints {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteWithTolerance);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns the geometry with repeated points removed");
@@ -1991,6 +2038,7 @@ struct ST_Reverse {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns the geometry with the order of its vertices reversed");
@@ -2021,6 +2069,7 @@ struct ST_ShortestLine {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns the shortest line between two geometries");
@@ -2049,6 +2098,7 @@ struct ST_Simplify {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns a simplified version of the geometry");
@@ -2078,6 +2128,7 @@ struct ST_SimplifyPreserveTopology {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns a simplified version of the geometry that preserves topology");
@@ -2103,6 +2154,7 @@ struct ST_Touches : SymmetricPreparedBinaryFunction<ST_Touches> {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns true if the geometries touch");
@@ -2133,6 +2185,7 @@ struct ST_Union {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns the union of two geometries");
@@ -2161,6 +2214,7 @@ struct ST_VoronoiDiagram {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns the Voronoi diagram of the supplied MultiPoint geometry");
@@ -2186,6 +2240,7 @@ struct ST_Within : AsymmetricPreparedBinaryFunction<ST_Within> {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription("Returns true if the first geometry is within the second");
@@ -2314,6 +2369,7 @@ struct ST_MemUnion_Agg : GeosUnaryAggFunction {
 
 		FunctionBuilder::RegisterAggregate(loader, "ST_MemUnion_Agg", [&](AggregateFunctionBuilder &func) {
 			func.SetFunction(agg);
+			func.CanThrowErrors();
 			func.SetDescription(R"(Computes the union of a set of input geometries.
 				"Slower, but might be more memory efficient than ST_UnionAgg as each geometry is merged into the union individually rather than all at once.)");
 
@@ -2339,6 +2395,7 @@ struct ST_Intersection_Agg : GeosUnaryAggFunction {
 
 		FunctionBuilder::RegisterAggregate(loader, "ST_Intersection_Agg", [&](AggregateFunctionBuilder &func) {
 			func.SetFunction(agg);
+			func.CanThrowErrors();
 			func.SetDescription("Computes the intersection of a set of geometries");
 
 			func.SetTag("ext", "spatial");
@@ -2531,6 +2588,7 @@ struct ST_Union_Agg {
 
 		FunctionBuilder::RegisterAggregate(loader, "ST_Union_Agg", [&](AggregateFunctionBuilder &func) {
 			func.SetFunction(agg);
+			func.CanThrowErrors();
 			func.SetDescription("Computes the union of a set of input geometries");
 
 			func.SetTag("ext", "spatial");
@@ -2796,11 +2854,13 @@ struct ST_CoverageSimplify_Agg : GEOSCoverageAggFunction {
 
 		FunctionBuilder::RegisterAggregate(loader, "ST_CoverageSimplify_Agg", [&](AggregateFunctionBuilder &func) {
 			func.SetFunction(agg);
+			func.CanThrowErrors();
 			func.SetDescription("Simplifies a set of geometries while maintaining coverage");
 
 			// TODO: this is a hack
 			agg.arguments.push_back(LogicalType::BOOLEAN);
 			func.SetFunction(agg);
+			func.CanThrowErrors();
 
 			func.SetTag("ext", "spatial");
 			func.SetTag("category", "construction");
@@ -2867,6 +2927,7 @@ struct ST_CoverageUnion_Agg : GEOSCoverageAggFunction {
 
 		FunctionBuilder::RegisterAggregate(loader, "ST_CoverageUnion_Agg", [&](AggregateFunctionBuilder &func) {
 			func.SetFunction(agg);
+			func.CanThrowErrors();
 			func.SetDescription("Unions a set of geometries while maintaining coverage");
 
 			func.SetTag("ext", "spatial");
@@ -2957,10 +3018,12 @@ struct ST_CoverageInvalidEdges_Agg : GEOSCoverageAggFunction {
 
 		FunctionBuilder::RegisterAggregate(loader, "ST_CoverageInvalidEdges_Agg", [&](AggregateFunctionBuilder &func) {
 			func.SetFunction(agg);
+			func.CanThrowErrors();
 
 			// TODO: this is a hack
 			agg.arguments.push_back(LogicalType::DOUBLE);
 			func.SetFunction(agg);
+			func.CanThrowErrors();
 
 			func.SetDescription("Returns the invalid edges of a coverage geometry");
 

--- a/src/spatial/modules/main/spatial_functions_aggregate.cpp
+++ b/src/spatial/modules/main/spatial_functions_aggregate.cpp
@@ -149,6 +149,7 @@ void RegisterSpatialAggregateFunctions(ExtensionLoader &loader) {
 		func.SetFunction(agg);
 		func.SetDescription(DOC_DESCRIPTION);
 		func.SetExample(DOC_EXAMPLE);
+		func.CanThrowErrors();
 
 		func.SetTag("ext", "spatial");
 		func.SetTag("category", "construction");
@@ -158,6 +159,7 @@ void RegisterSpatialAggregateFunctions(ExtensionLoader &loader) {
 		func.SetFunction(agg);
 		func.SetDescription(DOC_ALIAS_DESCRIPTION);
 		func.SetExample(DOC_EXAMPLE);
+		func.CanThrowErrors();
 
 		func.SetTag("ext", "spatial");
 		func.SetTag("category", "construction");

--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -1353,6 +1353,7 @@ struct ST_AsSVG {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -1992,6 +1993,7 @@ struct ST_CollectionExtract {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteTyped);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
@@ -2000,6 +2002,7 @@ struct ST_CollectionExtract {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteAuto);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -2352,6 +2355,7 @@ struct ST_Azimuth {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteGeometry);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
@@ -2992,6 +2996,7 @@ struct ST_Dump {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -3223,6 +3228,7 @@ struct ST_Extent {
 
 				variant.SetFunction(ExecuteWKB);
 				variant.SetInit(LocalState::Init);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -4650,6 +4656,7 @@ struct ST_GeomFromGeoJSON {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
@@ -4658,6 +4665,7 @@ struct ST_GeomFromGeoJSON {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -4780,6 +4788,7 @@ struct ST_GeomFromText {
 				variant.SetInit(LocalState::Init);
 				variant.SetBind(Bind);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
@@ -4790,6 +4799,7 @@ struct ST_GeomFromText {
 				variant.SetBind(Bind);
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DOCUMENTATION);
@@ -5070,6 +5080,7 @@ struct ST_GeomFromWKB {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecutePoint);
+				variant.CanThrowErrors();
 			});
 
 			builder.AddVariant([](ScalarFunctionVariantBuilder &variant) {
@@ -5078,6 +5089,7 @@ struct ST_GeomFromWKB {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecutePoint);
+				variant.CanThrowErrors();
 			});
 
 			builder.SetDescription("Deserialize a POINT_2D from a WKB encoded blob");
@@ -5394,6 +5406,7 @@ struct ST_LineInterpolatePoint {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteGeometry);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -5471,6 +5484,7 @@ struct ST_LineInterpolatePoints {
 
 				variant.SetFunction(ExecuteGeometry);
 				variant.SetInit(LocalState::Init);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -5542,6 +5556,7 @@ struct ST_LineLocatePoint {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteGeometry);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -5603,6 +5618,7 @@ struct ST_LineSubstring {
 
 				variant.SetFunction(ExecuteGeometry);
 				variant.SetInit(LocalState::Init);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -5692,6 +5708,7 @@ struct ST_LocateAlong {
 				variant.SetBind(Bind);
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteGeometry);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
@@ -5702,6 +5719,7 @@ struct ST_LocateAlong {
 				variant.SetBind(Bind);
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteGeometry);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -5828,6 +5846,7 @@ struct ST_LocateBetween {
 				variant.SetBind(Bind);
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteGeometry);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
@@ -5839,6 +5858,7 @@ struct ST_LocateBetween {
 				variant.SetBind(Bind);
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteGeometry);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -6049,6 +6069,7 @@ struct ST_Distance_Sphere {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteGeometry);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
@@ -6224,6 +6245,7 @@ struct ST_Hilbert {
 
 				variant.SetFunction(ExecuteGeometryWithBounds);
 				variant.SetInit(LocalState::Init);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
@@ -6327,6 +6349,7 @@ struct ST_InterpolatePoint {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteGeometry);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -6502,6 +6525,7 @@ struct ST_IsClosed {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -6950,6 +6974,7 @@ struct ST_MakeLine {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteList);
+				variant.CanThrowErrors();
 
 				variant.SetDescription(DESCRIPTION_LIST);
 				variant.SetExample(EXAMPLE_LIST);
@@ -6962,6 +6987,7 @@ struct ST_MakeLine {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteBinary);
+				variant.CanThrowErrors();
 
 				variant.SetDescription(DESCRIPTION_BINARY);
 				variant.SetExample(EXAMPLE_BINARY);
@@ -7100,6 +7126,7 @@ struct ST_MakePolygon {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteFromShell);
+				variant.CanThrowErrors();
 
 				// TODO: Set example & docs
 				variant.SetDescription("Create a POLYGON from a LINESTRING shell");
@@ -7114,6 +7141,7 @@ struct ST_MakePolygon {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteFromRings);
+				variant.CanThrowErrors();
 
 				// TODO: Set example & docs
 				variant.SetDescription("Create a POLYGON from a LINESTRING shell and a list of LINESTRING holes");
@@ -7216,6 +7244,7 @@ struct ST_MakeBox2D {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteBinary);
+				variant.CanThrowErrors();
 
 				variant.SetDescription(DESCRIPTION_BINARY);
 				variant.SetExample(EXAMPLE_BINARY);
@@ -8291,6 +8320,7 @@ struct ST_QuadKey {
 				variant.AddParameter("level", LogicalType::INTEGER);
 				variant.SetReturnType(LogicalType::VARCHAR);
 				variant.SetFunction(ExecuteLonLat);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
@@ -8299,6 +8329,7 @@ struct ST_QuadKey {
 				variant.SetReturnType(LogicalType::VARCHAR);
 				variant.SetFunction(ExecuteGeometry);
 				variant.SetInit(LocalState::Init);
+				variant.CanThrowErrors();
 			});
 
 			func.SetTag("ext", "spatial");
@@ -8975,6 +9006,7 @@ struct PointAccessFunctionBase {
 
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 
 				variant.SetDescription(OP::DESCRIPTION);
 				variant.SetExample(OP::EXAMPLE);

--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -4182,8 +4182,10 @@ struct ST_GeomFromHEXWKB {
 			for (idx_t hex_idx = 0; hex_idx < hex_size; hex_idx += 2) {
 				const auto byte_a = Blob::HEX_MAP[hex_ptr[hex_idx]];
 				const auto byte_b = Blob::HEX_MAP[hex_ptr[hex_idx + 1]];
-				D_ASSERT(byte_a != -1);
-				D_ASSERT(byte_b != -1);
+				if (byte_a == -1 || byte_b == -1) {
+					throw InvalidInputException("Invalid character in HEX WKB string: '%c%c'",
+					                            hex_ptr[hex_idx], hex_ptr[hex_idx + 1]);
+				}
 
 				blob_ptr[blob_idx++] = (byte_a << 4) + byte_b;
 			}
@@ -4233,6 +4235,7 @@ struct ST_GeomFromHEXWKB {
 
 					variant.SetInit(LocalState::Init);
 					variant.SetFunction(Execute);
+					variant.CanThrowErrors();
 				});
 
 				func.SetDescription(DESCRIPTION);

--- a/src/spatial/modules/mvt/mvt_module.cpp
+++ b/src/spatial/modules/mvt/mvt_module.cpp
@@ -158,6 +158,7 @@ struct ST_TileEnvelope {
 				variant.SetReturnType(GeoTypes::GEOMETRY());
 				variant.SetInit(LocalState::Init);
 				variant.SetFunction(ExecuteWebMercator);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -1282,6 +1283,7 @@ struct ST_AsMVT {
 			func.SetDescription(DESCRIPTION);
 			func.SetTag("ext", "spatial");
 			func.SetTag("category", "construction");
+			func.CanThrowErrors();
 		});
 	}
 };

--- a/src/spatial/modules/proj/proj_module.cpp
+++ b/src/spatial/modules/proj/proj_module.cpp
@@ -419,6 +419,7 @@ struct ST_Transform {
 				variant.SetInit(ProjFunctionLocalState::Init);
 				variant.SetBind(Bind);
 				variant.SetFunction(ExecuteBox);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([&](ScalarFunctionVariantBuilder &variant) {
@@ -431,6 +432,7 @@ struct ST_Transform {
 				variant.SetInit(ProjFunctionLocalState::Init);
 				variant.SetBind(Bind);
 				variant.SetFunction(ExecuteBox);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([&](ScalarFunctionVariantBuilder &variant) {
@@ -442,6 +444,7 @@ struct ST_Transform {
 				variant.SetInit(ProjFunctionLocalState::Init);
 				variant.SetBind(Bind);
 				variant.SetFunction(ExecutePoint);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([&](ScalarFunctionVariantBuilder &variant) {
@@ -454,6 +457,7 @@ struct ST_Transform {
 				variant.SetInit(ProjFunctionLocalState::Init);
 				variant.SetBind(Bind);
 				variant.SetFunction(ExecutePoint);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([&](ScalarFunctionVariantBuilder &variant) {
@@ -465,6 +469,7 @@ struct ST_Transform {
 				variant.SetInit(ProjFunctionLocalState::Init);
 				variant.SetBind(Bind);
 				variant.SetFunction(ExecuteGeometry);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([&](ScalarFunctionVariantBuilder &variant) {
@@ -477,6 +482,7 @@ struct ST_Transform {
 				variant.SetInit(ProjFunctionLocalState::Init);
 				variant.SetBind(Bind);
 				variant.SetFunction(ExecuteGeometry);
+				variant.CanThrowErrors();
 			});
 
 			func.SetDescription(DESCRIPTION);
@@ -689,12 +695,14 @@ struct ST_Area_Spheroid {
 
 				variant.SetInit(GeodesicLocalState::InitPolygon);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
 				variant.AddParameter("poly", GeoTypes::POLYGON_2D());
 				variant.SetReturnType(LogicalType::DOUBLE);
 				variant.SetFunction(ExecutePolygon);
+				variant.CanThrowErrors();
 			});
 
 			func.SetExample(EXAMPLE);
@@ -845,12 +853,14 @@ struct ST_Perimeter_Spheroid {
 
 				variant.SetInit(GeodesicLocalState::InitPolygon);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
 				variant.AddParameter("poly", GeoTypes::POLYGON_2D());
 				variant.SetReturnType(LogicalType::DOUBLE);
 				variant.SetFunction(ExecutePolygon);
+				variant.CanThrowErrors();
 			});
 
 			func.SetExample(EXAMPLE);
@@ -979,12 +989,14 @@ struct ST_Length_Spheroid {
 
 				variant.SetInit(GeodesicLocalState::InitLine);
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
 				variant.AddParameter("line", GeoTypes::LINESTRING_2D());
 				variant.SetReturnType(LogicalType::DOUBLE);
 				variant.SetFunction(ExecuteLineString);
+				variant.CanThrowErrors();
 			});
 
 			func.SetExample(EXAMPLE);
@@ -1044,6 +1056,7 @@ struct ST_Distance_Spheroid {
 				variant.SetReturnType(LogicalType::DOUBLE);
 
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetExample(EXAMPLE);
@@ -1097,6 +1110,7 @@ struct ST_DWithin_Spheroid {
 				variant.SetReturnType(LogicalType::BOOLEAN);
 
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetExample(EXAMPLE);
@@ -1139,6 +1153,7 @@ struct DuckDB_Proj_Version {
 				variant.SetReturnType(LogicalType::VARCHAR);
 
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetExample(EXAMPLE);
@@ -1179,6 +1194,7 @@ struct DuckDB_Proj_Compiled_Version {
 				variant.SetReturnType(LogicalType::VARCHAR);
 
 				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
 			});
 
 			func.SetExample(EXAMPLE);

--- a/src/spatial/util/function_builder.hpp
+++ b/src/spatial/util/function_builder.hpp
@@ -191,7 +191,7 @@ public:
 	void SetDescription(const string &desc);
 	void SetExample(const string &ex);
 	void SetFunction(const AggregateFunction &function);
-
+	void CanThrowErrors();
 private:
 	explicit AggregateFunctionBuilder(const char *name) : set(name) {
 	}
@@ -213,6 +213,12 @@ inline void AggregateFunctionBuilder::SetExample(const string &ex) {
 }
 inline void AggregateFunctionBuilder::SetTag(const string &key, const string &value) {
 	tags[key] = value;
+}
+
+inline void AggregateFunctionBuilder::CanThrowErrors() {
+	for (auto &function : set.functions) {
+		function.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/src/spatial/util/function_builder.hpp
+++ b/src/spatial/util/function_builder.hpp
@@ -55,6 +55,7 @@ public:
 	void SetBind(bind_scalar_function_t bind);
 	void SetDescription(const string &desc);
 	void SetExample(const string &ex);
+	void CanThrowErrors();
 
 private:
 	explicit ScalarFunctionVariantBuilder() : function({}, LogicalTypeId::INVALID, nullptr) {
@@ -92,6 +93,10 @@ inline void ScalarFunctionVariantBuilder::SetDescription(const string &desc) {
 
 inline void ScalarFunctionVariantBuilder::SetExample(const string &ex) {
 	description.examples.emplace_back(ex);
+}
+
+inline void ScalarFunctionVariantBuilder::CanThrowErrors() {
+	function.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
- Mark almost all scalar/aggregate functions that can throw errors as "CAN_THROW_RUNTIME_ERROR" to inform the optimizer when its safe to cache/move expression results
- Throw proper error message on invalid HEXWKB
- Update DuckDB to latest v1.4 commit
- Also backport https://github.com/duckdb/duckdb-spatial/pull/732 from main branch