### PR TITLE
Pin extension_ci_tools to 1.4 in 1.4 branch

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -25,20 +25,20 @@ concurrency:
 jobs:
   duckdb-latest-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4-andium
     with:
-      duckdb_version: v1.4.1
+      duckdb_version: v1.4.3
       extension_name: spatial
-      ci_tools_version: main
+      ci_tools_version: v1.4-andium
       vcpkg_commit: ce613c41372b23b1f51333815feb3edd87ef8a8b
 
   duckdb-latest-deploy:
     name: Deploy extension binaries
     needs: duckdb-latest-build
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@main
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.4-andium
     secrets: inherit
     with:
-      duckdb_version: v1.4.1
-      ci_tools_version: main
+      duckdb_version: v1.4.3
+      ci_tools_version: v1.4-andium
       extension_name: spatial
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
Due to the integration of duckdb/duckdb#19415 and
duckdb/extension-ci-tools#276 the `1.4-andium` branch of Spatial extension can no longer be built with `main` branch of `extension-ci-tools`.

This PR pins the version of `extension-ci-tools` used for CI builds. It should fix the following build problem on Windows:

```
error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MT_StaticRelease' doesn't match value 'MD_DynamicRelease'
```

Ref: duckdblabs/duckdb-internal#2036