### PR TITLE
Restore `duckdb_gdal_json.patch` format

### DIFF
--- a/vcpkg_ports/gdal/duckdb_gdal_json.patch
+++ b/vcpkg_ports/gdal/duckdb_gdal_json.patch
@@ -16,9 +16,9 @@ index 7a23c37..d42a134 100644
 --- a/ogr/ogrsf_frmts/geojson/libjson/json_object.c
 +++ b/ogr/ogrsf_frmts/geojson/libjson/json_object.c
 @@ -285,7 +285,7 @@ static int json_escape_str(struct printbuf *pb, const char *str, size_t len, int
-
+ 
  /* reference counting */
-
+ 
 -struct json_object *json_object_get(struct json_object *jso)
 +struct json_object *gdal__json_object_get(struct json_object *jso)
  {
@@ -34,7 +34,7 @@ index 05f25b0..085faca 100644
   */
 -JSON_EXPORT struct json_object *json_object_get(struct json_object *obj);
 +JSON_EXPORT struct json_object *gdal__json_object_get(struct json_object *obj);
-
+ 
  /**
   * Decrement the reference count of json_object and free if it reaches zero.
 @@ -152,14 +152,14 @@ JSON_EXPORT struct json_object *json_object_get(struct json_object *obj);
@@ -53,7 +53,7 @@ index 05f25b0..085faca 100644
 + * @see gdal__json_object_get()
   */
  JSON_EXPORT int json_object_put(struct json_object *obj);
-
+ 
 @@ -365,7 +365,7 @@ JSON_C_CONST_FUNCTION(JSON_EXPORT size_t json_c_object_sizeof(void));
   *
   * If you want to retain a reference to the added object, independent
@@ -90,13 +90,13 @@ index 1d24104..44fa630 100644
  			tok->depth--;
  			goto redo_char;
 @@ -1209,7 +1209,7 @@ out:
-
+ 
  	if (tok->err == json_tokener_success)
  	{
 -		json_object *ret = json_object_get(current);
 +		json_object *ret = gdal__json_object_get(current);
  		int ii;
-
+ 
  		/* Partially reset, so we parse additional objects on subsequent calls. */
 diff --git a/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp b/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
 index 274236e..19f9fdb 100644
@@ -110,16 +110,16 @@ index 274236e..19f9fdb 100644
 +            gdal__json_object_get(json_object_array_get_idx(poNativeCoordinates, i)));
      }
  }
-
+ 
 @@ -438,7 +438,7 @@ static void OGRGeoJSONPatchGeometry(json_object *poJSonGeometry,
              continue;
          }
-
+ 
 -        json_object_object_add(poJSonGeometry, it.key, json_object_get(it.val));
 +        json_object_object_add(poJSonGeometry, it.key, gdal__json_object_get(it.val));
      }
  }
-
+ 
 @@ -617,7 +617,7 @@ json_object *OGRGeoJSONWriteFeature(OGRFeature *poFeature,
                  }
                  if (strcmp(it.key, "geometry") == 0)
@@ -132,7 +132,7 @@ index 274236e..19f9fdb 100644
 @@ -696,7 +696,7 @@ json_object *OGRGeoJSONWriteFeature(OGRFeature *poFeature,
                      continue;
                  }
-
+ 
 -                json_object_object_add(poObj, it.key, json_object_get(it.val));
 +                json_object_object_add(poObj, it.key, gdal__json_object_get(it.val));
              }
@@ -159,7 +159,7 @@ index e2a5e2b..2dcc1dd 100644
 +                gdal__json_object_get(m_poAttributeFilter);
                  json_object_array_add(poConfig, m_poAttributeFilter);
              }
-
+ 
 @@ -1278,7 +1278,7 @@ GIntBig OGRPLScenesDataV1Layer::GetFeatureCount(int bForce)
          }
          if (m_poAttributeFilter != nullptr)
@@ -168,27 +168,27 @@ index e2a5e2b..2dcc1dd 100644
 +            gdal__json_object_get(m_poAttributeFilter);
              json_object_array_add(poConfig, m_poAttributeFilter);
          }
-
+ 
 diff --git a/port/cpl_json.cpp b/port/cpl_json.cpp
 index 99b2c7a..5b1778c 100644
 --- a/port/cpl_json.cpp
 +++ b/port/cpl_json.cpp
 @@ -82,7 +82,7 @@ CPLJSONDocument::~CPLJSONDocument()
  }
-
+ 
  CPLJSONDocument::CPLJSONDocument(const CPLJSONDocument &other)
 -    : m_poRootJsonObject(json_object_get(TO_JSONOBJ(other.m_poRootJsonObject)))
 +    : m_poRootJsonObject(gdal__json_object_get(TO_JSONOBJ(other.m_poRootJsonObject)))
  {
  }
-
+ 
 @@ -93,7 +93,7 @@ CPLJSONDocument &CPLJSONDocument::operator=(const CPLJSONDocument &other)
-
+ 
      if (m_poRootJsonObject)
          json_object_put(TO_JSONOBJ(m_poRootJsonObject));
 -    m_poRootJsonObject = json_object_get(TO_JSONOBJ(other.m_poRootJsonObject));
 +    m_poRootJsonObject = gdal__json_object_get(TO_JSONOBJ(other.m_poRootJsonObject));
-
+ 
      return *this;
  }
 @@ -202,7 +202,7 @@ void CPLJSONDocument::SetRoot(const CPLJSONObject &oRoot)
@@ -198,10 +198,10 @@ index 99b2c7a..5b1778c 100644
 -    m_poRootJsonObject = json_object_get(TO_JSONOBJ(oRoot.m_poJsonObject));
 +    m_poRootJsonObject = gdal__json_object_get(TO_JSONOBJ(oRoot.m_poJsonObject));
  }
-
+ 
  /**
 @@ -524,7 +524,7 @@ CPLJSONObject::CPLJSONObject(double dfVal)
-
+ 
  CPLJSONObject::CPLJSONObject(const std::string &osName,
                               const CPLJSONObject &oParent)
 -    : m_poJsonObject(json_object_get(json_object_new_object())), m_osKey(osName)
@@ -210,17 +210,17 @@ index 99b2c7a..5b1778c 100644
      json_object_object_add(TO_JSONOBJ(oParent.m_poJsonObject), osName.c_str(),
                             TO_JSONOBJ(m_poJsonObject));
 @@ -532,7 +532,7 @@ CPLJSONObject::CPLJSONObject(const std::string &osName,
-
+ 
  CPLJSONObject::CPLJSONObject(const std::string &osName,
                               JSONObjectH poJsonObject)
 -    : m_poJsonObject(json_object_get(TO_JSONOBJ(poJsonObject))), m_osKey(osName)
 +    : m_poJsonObject(gdal__json_object_get(TO_JSONOBJ(poJsonObject))), m_osKey(osName)
  {
  }
-
+ 
 @@ -561,7 +561,7 @@ CPLJSONObject::~CPLJSONObject()
  }
-
+ 
  CPLJSONObject::CPLJSONObject(const CPLJSONObject &other)
 -    : m_poJsonObject(json_object_get(TO_JSONOBJ(other.m_poJsonObject))),
 +    : m_poJsonObject(gdal__json_object_get(TO_JSONOBJ(other.m_poJsonObject))),
@@ -235,7 +235,7 @@ index 99b2c7a..5b1778c 100644
 +    m_poJsonObject = gdal__json_object_get(TO_JSONOBJ(other.m_poJsonObject));
      return *this;
  }
-
+ 
 @@ -762,7 +762,7 @@ void CPLJSONObject::Add(const std::string &osName, const CPLJSONArray &oValue)
      {
          json_object_object_add(
@@ -244,7 +244,7 @@ index 99b2c7a..5b1778c 100644
 +            gdal__json_object_get(TO_JSONOBJ(oValue.GetInternalHandle())));
      }
  }
-
+ 
 @@ -782,7 +782,7 @@ void CPLJSONObject::Add(const std::string &osName, const CPLJSONObject &oValue)
      {
          json_object_object_add(
@@ -262,7 +262,7 @@ index 99b2c7a..5b1778c 100644
 +            gdal__json_object_get(TO_JSONOBJ(oValue.GetInternalHandle())));
      }
  }
-
+ 
 @@ -812,7 +812,7 @@ void CPLJSONObject::AddNoSplitName(const std::string &osName,
      {
          json_object_object_add(
@@ -271,7 +271,7 @@ index 99b2c7a..5b1778c 100644
 +            gdal__json_object_get(TO_JSONOBJ(oValue.GetInternalHandle())));
      }
  }
-
+ 
 @@ -1479,7 +1479,7 @@ void CPLJSONArray::Add(const CPLJSONObject &oValue)
      if (m_poJsonObject && oValue.m_poJsonObject)
          json_object_array_add(
@@ -279,5 +279,5 @@ index 99b2c7a..5b1778c 100644
 -            json_object_get(TO_JSONOBJ(oValue.m_poJsonObject)));
 +            gdal__json_object_get(TO_JSONOBJ(oValue.m_poJsonObject)));
  }
-
+ 
  /**


### PR DESCRIPTION
When building using CMake according to CI commands, the only difference is that I used VS's sln instead of Ninja (`cmake -G "Visual Studio 16 2019" ...`). I received the following error (#738):

```text
D:\code\duckdb-spatial\./vcpkg_ports\gdal: info: installing overlay port from here
-- Using cached OSGeo-gdal-v3.8.5.tar.gz
-- Extracting source D:/code/vcpkg/downloads/OSGeo-gdal-v3.8.5.tar.gz
-- Applying patch find-link-libraries.patch
-- Applying patch fix-gdal-target-interfaces.patch
-- Applying patch libkml.patch
-- Applying patch target-is-valid.patch
-- Applying patch duckdb_gdal_json.patch
CMake Error at scripts/cmake/z_vcpkg_apply_patches.cmake:34 (message):
  Applying patch failed: error: corrupt patch at line 19
ilures?WT.mc_id=vcpkg_inproduct_cli for more information.
Elapsed time to handle gdal:x64-windows-static-md-release-vs2019comp: 12 s
Please ensure you're using the latest port files with `git pull` and `vcpkg update`.
Then check for known issues at:
  https://github.com/microsoft/vcpkg/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+gdal
You can submit a new issue at:
  https://github.com/microsoft/vcpkg/issues/new?title=[gdal]+Build+error+on+x64-windows-static-md-release-vs2019comp&body=Copy%20issue%20body%20from%20D%3A%2Fcode%2Fduckdb-spatial%2Fbuild%2Frelease%2Fvcpkg_installed%2Fvcpkg%2Fissue_body.md

Completed submission of json-c:x64-windows-static-md-release-vs2019comp@0.18-20240915 to 1 binary cache(s) in 202 ms
-- Running vcpkg install - failed
CMake Error at D:/code/vcpkg/scripts/buildsystems/vcpkg.cmake:953 (message):
  vcpkg install failed.  See logs for more information:
  D:\code\duckdb-spatial\build\release\vcpkg-manifest-install.log
Call Stack (most recent call first):
  D:/CMake/share/cmake-3.31/Modules/CMakeDetermineSystem.cmake:146 (include)
  CMakeLists.txt:23 (project)


-- Configuring incomplete, errors occurred!
```

I think there is an issue with the format of `duckdb_gdal_json.patch`. I created a clean file, and now I can generate and compile normally.