### PR TITLE
Update VCPKG baseline + don't special build CURL

### DIFF
--- a/test/sql/geos/st_maximuminscribedcircle.test
+++ b/test/sql/geos/st_maximuminscribedcircle.test
@@ -1,11 +1,11 @@
 require spatial
 
 query I
-SELECT st_maximuminscribedcircle('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::GEOMETRY);
+SELECT st_maximuminscribedcircle('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'::GEOMETRY).radius;
 ----
-{'center': 'POINT (0.5 0.5)', 'nearest': 'POINT (0.5 0)', 'radius': 0.5}
+0.5
 
 statement error
 SELECT st_maximuminscribedcircle('POLYGON EMPTY'::GEOMETRY);
 ----
-IllegalArgumentException: Empty input geometry is not supported
+Invalid Input Error: IllegalArgumentException: Empty input is not supported

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -17,9 +17,7 @@
     },
     {
       "name": "curl",
-      "platform": "!wasm32 & !ios & !android",
-      "features": ["openssl"],
-      "default-features": false
+      "platform": "!wasm32 & !ios & !android"
     },
     {
       "name": "gdal",
@@ -46,5 +44,5 @@
       }
     ]
   },
-  "builtin-baseline" : "ce613c41372b23b1f51333815feb3edd87ef8a8b"
+  "builtin-baseline" : "84bab45d415d22042bd0b9081aea57f362da3f35"
 }


### PR DESCRIPTION
Bumps VCPKG to the latest duckdb supported baseline.
Now that the `httpfs` extension also uses curl we need to build with the same feature flags when doing a static mega build.
