### PR TITLE
Apply patches, Misc R-Tree index fixes, Join optimization

### DIFF
--- a/src/spatial/index/rtree/rtree_index.cpp
+++ b/src/spatial/index/rtree/rtree_index.cpp
@@ -1,10 +1,14 @@
 #include "spatial/index/rtree/rtree_index.hpp"
 
+#include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/common/serializer/binary_deserializer.hpp"
 #include "duckdb/common/serializer/binary_serializer.hpp"
 #include "duckdb/execution/index/fixed_size_allocator.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 #include "duckdb/main/database.hpp"
+#include "spatial/spatial_types.hpp"
 #include "spatial/geometry/geometry_serialization.hpp"
 
 #include "spatial/index/rtree/rtree_module.hpp"
@@ -70,8 +74,8 @@ static RTreeConfig ParseOptions(const case_insensitive_map_t<Value> &options) {
 RTreeIndex::RTreeIndex(const string &name, IndexConstraintType index_constraint_type,
                        const vector<column_t> &column_ids, TableIOManager &table_io_manager,
                        const vector<unique_ptr<Expression>> &unbound_expressions, AttachedDatabase &db,
-                       const case_insensitive_map_t<Value> &options, const IndexStorageInfo &info,
-                       idx_t estimated_cardinality)
+                       const case_insensitive_map_t<Value> &options, ClientContext &context,
+                       const IndexStorageInfo &info, idx_t estimated_cardinality)
     : BoundIndex(name, TYPE_NAME, index_constraint_type, column_ids, table_io_manager, unbound_expressions, db) {
 
 	if (index_constraint_type != IndexConstraintType::NONE) {
@@ -101,6 +105,21 @@ RTreeIndex::RTreeIndex(const string &name, IndexConstraintType index_constraint_
 		// Set the root node and recalculate the bounds
 		tree->SetRoot(info.root);
 	}
+
+	// Construct the key expression executor
+	auto &source_type = unbound_expressions[0]->return_type;
+	auto &catalog = Catalog::GetSystemCatalog(context);
+	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "ST_Extent_Approx");
+	auto func = entry.functions.GetFunctionByArguments(context, {source_type});
+	auto child_expr = make_uniq<BoundReferenceExpression>(source_type, 0);
+
+	vector<unique_ptr<Expression>> children;
+	children.push_back(std::move(child_expr));
+
+	key_expr = make_uniq<BoundFunctionExpression>(GeoTypes::BOX_2DF(), func, std::move(children), nullptr);
+	key_executor = make_uniq<ExpressionExecutor>(context);
+	key_executor->AddExpression(*key_expr);
+	key_chunk.Initialize(context, {GeoTypes::BOX_2DF()});
 }
 
 unique_ptr<IndexScanState> RTreeIndex::InitializeScan(const RTreeBounds &query) const {
@@ -143,49 +162,51 @@ void RTreeIndex::CommitDrop(IndexLock &index_lock) {
 	tree->Reset();
 }
 
-ErrorData RTreeIndex::Insert(IndexLock &lock, DataChunk &input, Vector &rowid_vec) {
-	// TODO: Dont flatten chunk
-	input.Flatten();
 
-	auto &geom_vec = input.data[0];
-	const auto &geom_data = FlatVector::GetData<string_t>(geom_vec);
-	const auto &rowid_data = FlatVector::GetData<row_t>(rowid_vec);
+template<class CALLBACK = std::function<void(const RTreeEntry &)>>
+static void ConvertToEntries(Vector &box_vec, Vector &rowid_vec, idx_t count, CALLBACK &&callback) {
+	const auto &box_validity = FlatVector::Validity(box_vec);
+	const auto &row_validity = FlatVector::Validity(rowid_vec);
 
-	if (geom_data == nullptr || rowid_data == nullptr) {
-		return ErrorData {};
-	}
+	const auto &box_entries = StructVector::GetEntries(box_vec);
+	const auto box_xmin_data = FlatVector::GetData<float>(*box_entries[0]);
+	const auto box_ymin_data = FlatVector::GetData<float>(*box_entries[1]);
+	const auto box_xmax_data = FlatVector::GetData<float>(*box_entries[2]);
+	const auto box_ymax_data = FlatVector::GetData<float>(*box_entries[3]);
 
-	RTreeEntry entry_buffer[STANDARD_VECTOR_SIZE];
-	bool valid_buffer[STANDARD_VECTOR_SIZE];
+	const auto row_data = FlatVector::GetData<row_t>(rowid_vec);
 
-	for (idx_t i = 0; i < input.size(); i++) {
-		if (FlatVector::IsNull(geom_vec, i) || FlatVector::IsNull(rowid_vec, i)) {
-			valid_buffer[i] = false;
+	for (idx_t i = 0; i < count; i++) {
+		if (!box_validity.RowIsValid(i) || !row_validity.RowIsValid(i)) {
 			continue;
 		}
 
-		const auto rowid = rowid_data[i];
+		Box2D <float> box;
+		box.min.x = box_xmin_data[i];
+		box.min.y = box_ymin_data[i];
+		box.max.x = box_xmax_data[i];
+		box.max.y = box_ymax_data[i];
 
-		Box2D<float> bbox;
-		if (!Serde::TryGetBounds(geom_data[i], bbox)) {
-			valid_buffer[i] = false;
-			continue;
-		}
+		const auto row = row_data[i];
 
-		entry_buffer[i] = {RTree::MakeRowId(rowid), bbox};
-		valid_buffer[i] = true;
+		RTreeEntry new_entry = {RTree::MakeRowId(row), box};
+
+		// Invoke the callback with the new entry
+		callback(new_entry);
 	}
+}
 
-	// TODO: Investigate this more, is there a better way to insert multiple entries
-	// so that they produce a better tree?
-	// E.g. sort by x coordinate, or hilbert sort? or STR packing?
-	// Or insert by smallest first? or largest first?
-	// Or even create a separate subtree entirely, and then insert that into the root?
-	for (idx_t i = 0; i < input.size(); i++) {
-		if (valid_buffer[i]) {
-			tree->Insert(entry_buffer[i]);
-		}
-	}
+ErrorData RTreeIndex::Insert(IndexLock &lock, DataChunk &input, Vector &row_vec) {
+
+	key_chunk.Reset();
+	key_executor->ExecuteExpression(input, key_chunk.data[0]);
+	key_chunk.Flatten();
+
+	auto &box_vec = key_chunk.data[0];
+
+	ConvertToEntries(box_vec, row_vec, input.size(), [&](const RTreeEntry &entry) {
+		tree->Insert(entry);
+	});
 
 	return ErrorData {};
 }
@@ -197,38 +218,21 @@ ErrorData RTreeIndex::Append(IndexLock &lock, DataChunk &appended_data, Vector &
 	return Insert(lock, expr_chunk, row_identifiers);
 }
 
-void RTreeIndex::Delete(IndexLock &lock, DataChunk &input, Vector &rowid_vec) {
+void RTreeIndex::Delete(IndexLock &lock, DataChunk &input, Vector &row_vec) {
 	const auto count = input.size();
 
 	DataChunk expr_chunk;
 	expr_chunk.Initialize(Allocator::DefaultAllocator(), logical_types);
 	ExecuteExpressions(input, expr_chunk);
 
-	UnifiedVectorFormat geom_format;
-	UnifiedVectorFormat rowid_format;
+	key_chunk.Reset();
+	key_executor->ExecuteExpression(expr_chunk, key_chunk.data[0]);
+	key_chunk.Flatten();
 
-	expr_chunk.data[0].ToUnifiedFormat(count, geom_format);
-	rowid_vec.ToUnifiedFormat(count, rowid_format);
-
-	for (idx_t i = 0; i < count; i++) {
-		const auto geom_idx = geom_format.sel->get_index(i);
-		const auto rowid_idx = rowid_format.sel->get_index(i);
-
-		if (!geom_format.validity.RowIsValid(geom_idx) || !rowid_format.validity.RowIsValid(rowid_idx)) {
-			continue;
-		}
-
-		auto &geom = UnifiedVectorFormat::GetData<string_t>(geom_format)[geom_idx];
-		auto &rowid = UnifiedVectorFormat::GetData<row_t>(rowid_format)[rowid_idx];
-
-		Box2D<float> approx_bounds;
-		if (!Serde::TryGetBounds(geom, approx_bounds)) {
-			continue;
-		}
-
-		RTreeEntry new_entry = {RTree::MakeRowId(rowid), approx_bounds};
-		tree->Delete(new_entry);
-	}
+	auto &box_vec = key_chunk.data[0];
+	ConvertToEntries(box_vec, row_vec, count, [&](const RTreeEntry &entry) {
+		tree->Delete(entry);
+	});
 }
 
 IndexStorageInfo RTreeIndex::SerializeToDisk(QueryContext context, const case_insensitive_map_t<Value> &options) {

--- a/src/spatial/index/rtree/rtree_index.hpp
+++ b/src/spatial/index/rtree/rtree_index.hpp
@@ -20,17 +20,22 @@ public:
 public:
 	RTreeIndex(const string &name, IndexConstraintType index_constraint_type, const vector<column_t> &column_ids,
 	           TableIOManager &table_io_manager, const vector<unique_ptr<Expression>> &unbound_expressions,
-	           AttachedDatabase &db, const case_insensitive_map_t<Value> &options,
+	           AttachedDatabase &db, const case_insensitive_map_t<Value> &options, ClientContext &context,
 	           const IndexStorageInfo &info = IndexStorageInfo(), idx_t estimated_cardinality = 0);
 
 	unique_ptr<RTree> tree;
+
+	// To compute bounding boxes when inserting
+	DataChunk key_chunk;
+	unique_ptr<Expression> key_expr;
+	unique_ptr<ExpressionExecutor> key_executor;
 
 	unique_ptr<IndexScanState> InitializeScan(const Box2D<float> &query) const;
 	idx_t Scan(IndexScanState &state, Vector &result) const;
 
 	static unique_ptr<BoundIndex> Create(CreateIndexInput &input) {
 		auto res = make_uniq<RTreeIndex>(input.name, input.constraint_type, input.column_ids, input.table_io_manager,
-		                                 input.unbound_expressions, input.db, input.options, input.storage_info);
+		                                 input.unbound_expressions, input.db, input.options, input.context, input.storage_info);
 		return std::move(res);
 	}
 

--- a/src/spatial/index/rtree/rtree_index_create_physical.cpp
+++ b/src/spatial/index/rtree/rtree_index_create_physical.cpp
@@ -78,7 +78,7 @@ unique_ptr<GlobalSinkState> PhysicalCreateRTreeIndex::GetGlobalSinkState(ClientC
 	auto &db = storage.db;
 	gstate->rtree =
 	    make_uniq<RTreeIndex>(info->index_name, constraint_type, storage_ids, table_manager, unbound_expressions, db,
-	                          info->options, IndexStorageInfo(), estimated_cardinality);
+	                          info->options, context, IndexStorageInfo(), estimated_cardinality);
 
 	gstate->max_node_capacity = gstate->rtree->tree->GetConfig().max_node_capacity;
 	gstate->entry_idx = gstate->max_node_capacity;

--- a/src/spatial/index/rtree/rtree_index_plan_scan.cpp
+++ b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
@@ -189,7 +189,7 @@ public:
 
 		unordered_set<string> spatial_predicates = {"ST_Equals",    "ST_Intersects",      "ST_Touches",  "ST_Crosses",
 		                                            "ST_Within",    "ST_Contains",        "ST_Overlaps", "ST_Covers",
-		                                            "ST_CoveredBy", "ST_ContainsProperly"};
+		                                            "ST_CoveredBy", "ST_ContainsProperly", "&&", "ST_IntersectsExtent"};
 
 		table_info.BindIndexes(context, RTreeIndex::TYPE_NAME);
 

--- a/src/spatial/index/rtree/rtree_index_plan_scan.cpp
+++ b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
@@ -192,7 +192,8 @@ public:
 		                                            "ST_CoveredBy", "ST_ContainsProperly"};
 
 		table_info.BindIndexes(context, RTreeIndex::TYPE_NAME);
-		table_info.GetIndexes().Scan([&](Index &index) {
+
+		for (auto &index : table_info.GetIndexes().Indexes()) {
 			if (!index.IsBound() || RTreeIndex::TYPE_NAME != index.GetIndexType()) {
 				return false;
 			}
@@ -210,7 +211,7 @@ public:
 			}
 			if (!rewrite_possible) {
 				// Could not rewrite!
-				return false;
+				continue;
 			}
 
 			FunctionExpressionMatcher matcher;
@@ -223,7 +224,7 @@ public:
 
 			vector<reference<Expression>> bindings;
 			if (!matcher.Match(*filter_expr, bindings)) {
-				return false;
+				continue;
 			}
 
 			// 		bindings[0] = the expression
@@ -234,12 +235,12 @@ public:
 			auto constant_value = bindings[2].get().Cast<BoundConstantExpression>().value;
 			Box2D<float> bbox;
 			if (!TryGetBoundingBox(constant_value, bbox)) {
-				return false;
+				continue;
 			}
 
 			bind_data = make_uniq<RTreeIndexScanBindData>(duck_table, index_entry, bbox);
-			return true;
-		});
+			break;
+		};
 
 		if (!bind_data) {
 			// No index found

--- a/src/spatial/index/rtree/rtree_index_plan_scan.cpp
+++ b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
@@ -8,6 +8,7 @@
 #include "spatial/util/math.hpp"
 
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/function/table/table_scan.hpp"
 #include "duckdb/optimizer/column_binding_replacer.hpp"
 #include "duckdb/optimizer/column_lifetime_analyzer.hpp"
@@ -115,9 +116,37 @@ public:
 		return true;
 	}
 
-	static bool TryGetBoundingBox(const Value &value, Box2D<float> &bbox) {
-		const auto blob = value.GetValueUnsafe<string_t>();
-		return Serde::TryGetBounds(blob, bbox) != 0;
+	static bool TryGetBoundingBox(ClientContext &context, const Expression &expr, Box2D<float> &bbox) {
+
+		// make a new box expression
+		auto &catalog = Catalog::GetSystemCatalog(context);
+		auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, DEFAULT_SCHEMA, "ST_Extent_Approx");
+		auto func = entry.functions.GetFunctionByArguments(context, {LogicalType::GEOMETRY()});
+
+		vector<unique_ptr<Expression>> children;
+		children.push_back(expr.Copy());
+
+		const auto bbox_expr = make_uniq<BoundFunctionExpression>(GeoTypes::BOX_2DF(), func, std::move(children), nullptr);
+
+		Value result;
+		if (!ExpressionExecutor::TryEvaluateScalar(context, *bbox_expr, result)) {
+			return false;
+		}
+		if (result.IsNull()) {
+			return false;
+		}
+
+		auto &parts = StructValue::GetChildren(result);
+		if (parts.size() != 4) {
+			return false;
+		}
+
+		bbox.min.x = parts[0].GetValue<float>();
+		bbox.min.y = parts[1].GetValue<float>();
+		bbox.max.x = parts[2].GetValue<float>();
+		bbox.max.y = parts[3].GetValue<float>();
+
+		return true;
 	}
 
 	static bool TryOptimize(Binder &binder, ClientContext &context, unique_ptr<LogicalOperator> &plan,
@@ -232,9 +261,8 @@ public:
 			// 		bindings[2] = the constant
 
 			// Compute the bounding box
-			auto constant_value = bindings[2].get().Cast<BoundConstantExpression>().value;
 			Box2D<float> bbox;
-			if (!TryGetBoundingBox(constant_value, bbox)) {
+			if (!TryGetBoundingBox(context, bindings[2], bbox)) {
 				continue;
 			}
 

--- a/src/spatial/index/rtree/rtree_index_pragmas.cpp
+++ b/src/spatial/index/rtree/rtree_index_pragmas.cpp
@@ -77,17 +77,16 @@ static void RTreeIndexInfoExecute(ClientContext &context, TableFunctionInput &da
 
 		auto &table_info = *storage.GetDataTableInfo();
 		table_info.BindIndexes(context, RTreeIndex::TYPE_NAME);
-		table_info.GetIndexes().Scan([&](Index &index) {
+		for (auto &index : table_info.GetIndexes().Indexes()) {
 			if (!index.IsBound() || RTreeIndex::TYPE_NAME != index.GetIndexType()) {
-				return false;
+				continue;
 			}
 			auto &rtree = index.Cast<RTreeIndex>();
 			if (rtree.name == index_entry.name) {
 				rtree_index = &rtree;
-				return true;
+				break;
 			}
-			return false;
-		});
+		};
 
 		if (!rtree_index) {
 			throw BinderException("Index %s not found", index_entry.name);
@@ -121,17 +120,16 @@ static optional_ptr<RTreeIndex> TryGetIndex(ClientContext &context, const string
 
 	auto &table_info = *storage.GetDataTableInfo();
 	table_info.BindIndexes(context, RTreeIndex::TYPE_NAME);
-	table_info.GetIndexes().Scan([&](Index &index) {
+	for (auto &index : table_info.GetIndexes().Indexes()) {
 		if (!index.IsBound() || RTreeIndex::TYPE_NAME != index.GetIndexType()) {
-			return false;
+			continue;
 		}
 		auto &rtree = index.Cast<RTreeIndex>();
 		if (index_entry.name == index_name) {
 			rtree_index = &rtree;
-			return true;
+			break;
 		}
-		return false;
-	});
+	};
 
 	return rtree_index;
 }

--- a/src/spatial/index/rtree/rtree_index_scan.cpp
+++ b/src/spatial/index/rtree/rtree_index_scan.cpp
@@ -214,17 +214,16 @@ static unique_ptr<FunctionData> RTreeScanDeserialize(Deserializer &deserializer,
 	unique_ptr<RTreeIndexScanBindData> result = nullptr;
 
 	table_info.BindIndexes(context, RTreeIndex::TYPE_NAME);
-	table_info.GetIndexes().Scan([&](Index &index) {
+	for (auto &index : table_info.GetIndexes().Indexes()) {
 		if (!index.IsBound() || RTreeIndex::TYPE_NAME != index.GetIndexType()) {
-			return false;
+			continue;
 		}
 		auto &index_entry = index.Cast<RTreeIndex>();
 		if (index_entry.GetIndexName() == index_name) {
 			result = make_uniq<RTreeIndexScanBindData>(duck_table, index_entry, bbox);
-			return true;
+			break;
 		}
-		return false;
-	});
+	};
 
 	if (!result) {
 		throw SerializationException("Could not find index %s on table %s.%s", index_name, schema, table);

--- a/src/spatial/index/rtree/rtree_index_scan.cpp
+++ b/src/spatial/index/rtree/rtree_index_scan.cpp
@@ -100,13 +100,25 @@ static void RTreeIndexScanExecute(ClientContext &context, TableFunctionInput &da
 
 	// Scan the index for row id's
 	auto row_count = bind_data.index.Cast<RTreeIndex>().Scan(*state.index_state, state.row_ids);
+
 	if (row_count == 0) {
-		// Short-circuit if the index had no more rows
-		output.SetCardinality(0);
-		return;
+		// Index is exhausted, fetch from local storage instead.
+		// This won't be indexed, but at least we get the correct results.
+		auto &local_storage = LocalStorage::Get(transaction);
+
+		// If there are no projection ids, we can directly scan into the output
+		if (state.projection_ids.empty()) {
+			local_storage.Scan(state.local_storage_state.local_state, state.column_ids, output);
+			return;
+		}
+
+		// Otherwise we need to scan into our scan chunk, and then project out the result
+		state.all_columns.Reset();
+		local_storage.Scan(state.local_storage_state.local_state, state.column_ids, state.all_columns);
+		output.ReferenceColumns(state.all_columns, state.projection_ids);
 	}
 
-	// Fetch the data from the local storage given the row ids
+	// Fetch the data from the main storage given the row ids
 	if (state.projection_ids.empty()) {
 		bind_data.table.GetStorage().Fetch(transaction, output, state.column_ids, state.row_ids, row_count,
 		                                   state.fetch_state);

--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -27,6 +27,7 @@
 #include "cpl_vsi.h"
 #include "cpl_vsi_error.h"
 #include "cpl_vsi_virtual.h"
+#include "duckdb/common/types/geometry_crs.hpp"
 #include "duckdb/main/settings.hpp"
 
 namespace duckdb {
@@ -611,7 +612,7 @@ auto Bind(ClientContext &ctx, TableFunctionBindInput &input, vector<LogicalType>
 		// Convert Arrow schema to DuckDB types
 		for (int64_t i = 0; i < schema.n_children; i++) {
 			auto &child_schema = *schema.children[i];
-			const auto gdal_type = ArrowType::GetTypeFromSchema(ctx.db->config, child_schema);
+			const auto gdal_type = ArrowType::GetTypeFromSchema(ctx, child_schema);
 			auto duck_type = gdal_type->GetDuckType();
 
 			// Track geometry columns to compute stats later
@@ -849,7 +850,7 @@ auto InitGlobal(ClientContext &context, TableFunctionInitInput &input) -> unique
 	// Store the column types
 	for (int64_t i = 0; i < schema.n_children; i++) {
 		auto &child_schema = *schema.children[i];
-		result->col_types.push_back(ArrowType::GetTypeFromSchema(context.db->config, child_schema));
+		result->col_types.push_back(ArrowType::GetTypeFromSchema(context, child_schema));
 	}
 
 	return std::move(result);
@@ -1197,6 +1198,16 @@ auto Bind(ClientContext &context, CopyFunctionBindInput &input, const vector<str
 		}
 
 		throw BinderException("Unknown GDAL COPY option: '%s'", option.first);
+	}
+
+	// If no override SRS is set, we will use the SRS of the first geometry column
+	if (result->target_srs.empty()) {
+		for (auto &col : sql_types) {
+			if (col.id() == LogicalTypeId::GEOMETRY && GeoType::HasCRS(col)) {
+				result->target_srs = GeoType::GetCRS(col).GetDefinition();
+				break;
+			}
+		}
 	}
 
 	// Check that options are valid

--- a/src/spatial/modules/main/spatial_functions.hpp
+++ b/src/spatial/modules/main/spatial_functions.hpp
@@ -25,4 +25,10 @@ public:
 	static void Box2DToVarchar(Vector &source, Vector &result, idx_t count);
 };
 
+struct CastParameters;
+struct SpatialCasts {
+	bool FromLegacyGeometryCast(Vector &source, Vector &result, idx_t count, CastParameters &params);
+
+};
+
 } // namespace duckdb

--- a/src/spatial/modules/main/spatial_functions_cast.cpp
+++ b/src/spatial/modules/main/spatial_functions_cast.cpp
@@ -275,7 +275,7 @@ struct GeometryCasts {
 		}
 	}
 
-	static bool FromLegacyGeometryCast(Vector &source, Vector &result, idx_t count, CastParameters &params) {
+	 static bool FromLegacyGeometryCast(Vector &source, Vector &result, idx_t count, CastParameters &params) {
 		UnaryExecutor::Execute<string_t, string_t>(source, result, count, [&](const string_t &old_blob) {
 			BinaryReader reader(old_blob.GetDataUnsafe(), old_blob.GetSize());
 
@@ -1079,6 +1079,12 @@ struct BoxCasts {
 
 } // namespace
 
+// Re-export this function
+bool SpatialCasts::FromLegacyGeometryCast(Vector &source, Vector &result, idx_t count, CastParameters &params) {
+	return GeometryCasts::FromLegacyGeometryCast(source, result, count, params);
+}
+
+
 //======================================================================================================================
 // Vector Operations
 //======================================================================================================================
@@ -1123,6 +1129,7 @@ void CoreVectorOperations::Point3DToVarchar(Vector &source, Vector &result, idx_
 		return StringVector::AddString(result, StringUtil::Format("POINT Z (%s)", MathUtil::format_coord(x, y, z)));
 	});
 }
+
 
 //------------------------------------------------------------------------------
 // POINT_4D -> VARCHAR

--- a/src/spatial/modules/proj/proj_module.cpp
+++ b/src/spatial/modules/proj/proj_module.cpp
@@ -8,6 +8,10 @@
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/common/types/geometry_crs.hpp"
+#include "duckdb/parser/parsed_data/create_coordinate_system_info.hpp"
+#include "duckdb/catalog/catalog_entry/coordinate_system_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/duck_schema_entry.hpp"
 
 #include "proj.h"
 #include "geodesic.h"
@@ -1208,6 +1212,133 @@ struct DuckDB_Proj_Compiled_Version {
 
 } // namespace
 
+//======================================================================================================================
+// CRS Provider
+//======================================================================================================================
+namespace {
+
+class SpatialCoordinateSystemGenerator : public DefaultGenerator {
+private:
+
+	SchemaCatalogEntry &schema;
+	PJ_CONTEXT *ctx = nullptr;
+	mutex proj_mutex;
+
+public:
+	SpatialCoordinateSystemGenerator(Catalog &catalog, SchemaCatalogEntry &schema) : DefaultGenerator(catalog), schema(schema) {
+		ctx = ProjModule::GetThreadProjContext();
+	}
+
+	~SpatialCoordinateSystemGenerator() override {
+		if (ctx) {
+			proj_context_destroy(ctx);
+			ctx = nullptr;
+		}
+	}
+
+public:
+	unique_ptr<CatalogEntry> CreateDefaultEntry(ClientContext &context, const string &entry_name) override {
+
+		if (schema.name != DEFAULT_SCHEMA) {
+			return nullptr;
+		}
+
+		// Try to split name by ":"
+		auto parts = StringUtil::Split(entry_name, ":");
+		if (parts.size() != 2) {
+			return nullptr;
+		}
+
+		auto auth_name = parts[0];
+		auto auth_code = parts[1];
+
+		// We only support OGC and EPSG for now
+		if (!StringUtil::CIEquals(auth_name, "EPSG") && !StringUtil::CIEquals(auth_name, "OGC")) {
+			return nullptr;
+		}
+
+		// Create PJ object
+		lock_guard<mutex> lock(proj_mutex);
+
+		PJ* crs = proj_create_from_database(ctx, auth_name.c_str(), auth_code.c_str(), PJ_CATEGORY_CRS, false, nullptr);
+		if (!crs) {
+			return nullptr;
+		}
+
+		// Export to WKT2_2019
+		string wkt_text;
+		static const char *const options[] = {"MULTILINE=NO", nullptr};
+		const auto wkt = proj_as_wkt(ctx, crs, PJ_WKT2_2019, options);
+		if (wkt) {
+			wkt_text = wkt;
+		}
+
+		// Export to PROJJSON
+		string projjson_text;
+		const auto pj_json = proj_as_projjson(ctx, crs, options);
+		if (pj_json) {
+			projjson_text = pj_json;
+		}
+
+		proj_destroy(crs);
+
+		auto info = CreateCoordinateSystemInfo(entry_name, auth_name, auth_code, projjson_text, wkt_text);
+		info.on_conflict = OnCreateConflict::IGNORE_ON_CONFLICT;
+
+		auto result = make_uniq<CoordinateSystemCatalogEntry>(catalog, schema, info);
+		return std::move(result);
+	}
+
+	vector<string> GetDefaultEntries() override {
+
+		if (schema.name != DEFAULT_SCHEMA) {
+			return {};
+		}
+
+		vector<string> entries;
+
+		auto scan_authority = [&](const char* auth) {
+			int ncrs = 0;
+			PROJ_CRS_INFO **crs_info = proj_get_crs_info_list_from_database(ctx, auth, nullptr, &ncrs);
+
+			if (crs_info) {
+				for (int i = 0; i < ncrs; i++) {
+					auto &auth_name = crs_info[i]->auth_name;
+					auto &auth_code = crs_info[i]->code;
+
+					if (!auth_name || !auth_code) {
+						continue;
+					}
+
+					entries.push_back(StringUtil::Format("%s:%s", auth_name, auth_code));
+				}
+			}
+
+			proj_crs_info_list_destroy(crs_info);
+		};
+
+		// Scan EPSG and OGC authority lists
+		lock_guard<mutex> lock(proj_mutex);
+		scan_authority("epsg");
+		scan_authority("OGC");
+
+		return entries;
+	}
+
+	static void Register(ExtensionLoader &loader) {
+
+		auto &db = loader.GetDatabaseInstance();
+		auto system_transaction = CatalogTransaction::GetSystemTransaction(db);
+		auto &catalog = Catalog::GetSystemCatalog(db);
+		auto &schema = catalog.GetSchema(system_transaction, DEFAULT_SCHEMA);
+		auto &duck_schema = schema.Cast<DuckSchemaEntry>();
+
+		auto &set = duck_schema.GetCatalogSet(CatalogType::COORDINATE_SYSTEM_ENTRY);
+		set.SetDefaultGenerator(make_uniq<SpatialCoordinateSystemGenerator>(catalog, schema));
+	}
+};
+
+} // namespace
 //######################################################################################################################
 // Module Registration
 //######################################################################################################################
@@ -1229,6 +1360,8 @@ void RegisterProjModule(ExtensionLoader &loader) {
 	// Meta functions for proj lib
 	DuckDB_Proj_Version::Register(loader);
 	DuckDB_Proj_Compiled_Version::Register(loader);
+
+	SpatialCoordinateSystemGenerator::Register(loader);
 }
 
 } // namespace duckdb

--- a/src/spatial/operators/spatial_join_optimizer.cpp
+++ b/src/spatial/operators/spatial_join_optimizer.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/planner/operator/logical_any_join.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/optimizer/optimizer_extension.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
 
@@ -16,23 +17,25 @@ namespace duckdb {
 
 // All of these imply bounding box intersection
 static const case_insensitive_set_t spatial_predicate_map = {
-    "ST_Equals",   "ST_Intersects", "ST_Touches",   "ST_Crosses",          "ST_Within",         "ST_Contains",
+    "&&", "ST_IntersectsExtent", "ST_Equals",   "ST_Intersects", "ST_Touches",   "ST_Crosses",          "ST_Within",         "ST_Contains",
     "ST_Overlaps", "ST_Covers",     "ST_CoveredBy", "ST_ContainsProperly", "ST_WithinProperly", "ST_DWithin",
 };
 
 static const case_insensitive_map_t<string> spatial_predicate_inverse_map = {
     {"ST_Equals", "ST_Equals"},
-    {"ST_Intersects", "ST_Intersects"},           // Symmetric
-    {"ST_Touches", "ST_Touches"},                 // Symmetric
-    {"ST_Crosses", "ST_Crosses"},                 // Symmetric
-    {"ST_Within", "ST_Contains"},                 // Inverse
-    {"ST_Contains", "ST_Within"},                 // Inverse
-    {"ST_Overlaps", "ST_Overlaps"},               // Symmetric
-    {"ST_Covers", "ST_CoveredBy"},                // Inverse
-    {"ST_CoveredBy", "ST_Covers"},                // Inverse
-    {"ST_WithinProperly", "ST_ContainsProperly"}, // Inverse
-    {"ST_ContainsProperly", "ST_WithinProperly"}, // Inverse
-    {"ST_DWithin", "ST_DWithin"},                 // Symmetric (when distance is constant)
+	{"&&", "&&"},									// Symmetric
+	{"ST_IntersectsExtent", "ST_IntersectsExtent"},	// Symmetric
+	{"ST_Intersects", "ST_Intersects"},				// Symmetric
+    {"ST_Touches", "ST_Touches"},					// Symmetric
+    {"ST_Crosses", "ST_Crosses"},                 	// Symmetric
+    {"ST_Within", "ST_Contains"},                 	// Inverse
+    {"ST_Contains", "ST_Within"},                 	// Inverse
+    {"ST_Overlaps", "ST_Overlaps"},               	// Symmetric
+    {"ST_Covers", "ST_CoveredBy"},                	// Inverse
+    {"ST_CoveredBy", "ST_Covers"},                	// Inverse
+    {"ST_WithinProperly", "ST_ContainsProperly"}, 	// Inverse
+    {"ST_ContainsProperly", "ST_WithinProperly"}, 	// Inverse
+    {"ST_DWithin", "ST_DWithin"},                 	// Symmetric (when distance is constant)
 };
 
 static bool HasInversePredicate(const string &func_name) {
@@ -226,15 +229,6 @@ static void TrySwapAnyJoin(OptimizerExtensionInput &input, unique_ptr<LogicalOpe
 	LogicalJoin::GetTableReferences(*left_child, left_bindings);
 	LogicalJoin::GetTableReferences(*right_child, right_bindings);
 
-	// TODO: Only support a single predicate for now
-	if (expressions.size() != 1) {
-		return;
-	}
-
-	// TODO: This whole logic is a work in progress.
-	// it does a bunch of extra work trying to separate the predicates, which doesnt matter because we only support
-	// a single join condition for now anyway
-
 	// The spatial join condition
 	unique_ptr<Expression> spatial_pred_expr = nullptr;
 
@@ -244,24 +238,19 @@ static void TrySwapAnyJoin(OptimizerExtensionInput &input, unique_ptr<LogicalOpe
 	// Now, check each expression to see if it contains a spatial predicate
 	for (auto &expr : expressions) {
 
-		if (spatial_pred_expr) {
-			// We already have a spatial predicate, so this must be an extra condition
-			extra_predicates.push_back(std::move(expr));
-			continue;
-		}
-
+		// This is a valid spatial predicate, and we haven't found a spatial predicate yet.
 		bool needs_flipping = false;
-		if (!IsSpatialJoinPredicate(expr, left_bindings, right_bindings, needs_flipping)) {
-			// Not a spatial predicate
-			extra_predicates.push_back(std::move(expr));
+		if (IsSpatialJoinPredicate(expr, left_bindings, right_bindings, needs_flipping) && !spatial_pred_expr) {
+
+			if (needs_flipping) {
+				expr = GetInversePredicate(input.context, std::move(expr));
+			}
+
+			spatial_pred_expr = std::move(expr);
 			continue;
 		}
 
-		if (needs_flipping) {
-			expr = GetInversePredicate(input.context, std::move(expr));
-		}
-
-		spatial_pred_expr = std::move(expr);
+		extra_predicates.push_back(std::move(expr));
 	}
 
 	// Nope! No spatial predicate found
@@ -269,14 +258,17 @@ static void TrySwapAnyJoin(OptimizerExtensionInput &input, unique_ptr<LogicalOpe
 		return;
 	}
 
-	// TODO: Push a filter for the extra conditions?
+	// If, and only if this is INNER join, we can push the extra predicates as filters
+	if (any_join.join_type != JoinType::INNER && !extra_predicates.empty()) {
+		return;
+	}
 
 	// Cool, now we have spatial join conditions. Proceed to create a new LogicalSpatialJoin operator
 	auto spatial_join = make_uniq<LogicalSpatialJoin>(any_join.join_type);
 
 	// Steal the properties from the any-join
 	spatial_join->spatial_predicate = std::move(spatial_pred_expr);
-	spatial_join->extra_conditions = std::move(extra_predicates);
+	// spatial_join->extra_conditions = std::move(extra_predicates);
 	spatial_join->children = std::move(any_join.children);
 	spatial_join->expressions = std::move(any_join.expressions);
 	spatial_join->types = std::move(any_join.types);
@@ -293,6 +285,17 @@ static void TrySwapAnyJoin(OptimizerExtensionInput &input, unique_ptr<LogicalOpe
 		// Try to get the constant distance value from the bind data;
 		spatial_join->has_const_distance =
 		    ST_DWithinHelper::TryGetConstDistance(pred_func.bind_info, spatial_join->const_distance);
+	}
+
+	if (spatial_join->join_type == JoinType::INNER && !extra_predicates.empty()) {
+		// Create a filter on top of the spatial join for the extra predicates
+		auto filter = make_uniq<LogicalFilter>();
+		filter->expressions = std::move(extra_predicates);
+		filter->children.push_back(std::move(spatial_join));
+
+		// Replace the operator
+		plan = std::move(filter);
+		return;
 	}
 
 	// Replace the operator

--- a/test/sql/index/rtree_transaction.test
+++ b/test/sql/index/rtree_transaction.test
@@ -13,27 +13,12 @@ CREATE OR REPLACE TABLE points AS SELECT row_number() over () as id, geom::GEOME
 statement ok
 CREATE INDEX my_idx ON points USING RTREE(geom);
 
-query II
-SELECT * FROM points WHERE geom && ST_MakeEnvelope(0, 0, 500, 500);
+query I
+SELECT id FROM points WHERE geom && ST_MakeEnvelope(0, 0, 500, 500);
 ----
-351	POINT (359.812940005213 406.6655575297773)
-472	POINT (169.11179292947054 129.24372218549252)
-775	POINT (173.61568519845605 455.52933821454644)
+351
+472
+775
 
-
-#statement ok
-#BEGIN TRANSACTION;
-#
-#statement ok
-#CREATE OR REPLACE TABLE points AS SELECT row_number() over () as id, geom::GEOMETRY as geom
-#  FROM st_generatepoints({min_x: 0, min_y: 0, max_x: 10000, max_y: 10000}::BOX_2D, 1000, 1337) as pts(geom);
-#
-#statement ok
-#CREATE INDEX my_idx ON points USING RTREE(geom);
-#
-#query II
-#SELECT * FROM points WHERE geom && ST_MakeEnvelope(0, 0, 500, 500);
-#----
-#351	POINT (359.812940005213 406.6655575297773)
-#472	POINT (169.11179292947054 129.24372218549252)
-#775	POINT (173.61568519845605 455.52933821454644)
+statement ok
+COMMIT;

--- a/test/sql/index/rtree_transaction.test
+++ b/test/sql/index/rtree_transaction.test
@@ -1,0 +1,39 @@
+require spatial
+
+statement ok
+PRAGMA enable_verification;
+
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+CREATE OR REPLACE TABLE points AS SELECT row_number() over () as id, geom::GEOMETRY as geom
+  FROM st_generatepoints({min_x: 0, min_y: 0, max_x: 10000, max_y: 10000}::BOX_2D, 1000, 1337) as pts(geom);
+
+statement ok
+CREATE INDEX my_idx ON points USING RTREE(geom);
+
+query II
+SELECT * FROM points WHERE geom && ST_MakeEnvelope(0, 0, 500, 500);
+----
+351	POINT (359.812940005213 406.6655575297773)
+472	POINT (169.11179292947054 129.24372218549252)
+775	POINT (173.61568519845605 455.52933821454644)
+
+
+#statement ok
+#BEGIN TRANSACTION;
+#
+#statement ok
+#CREATE OR REPLACE TABLE points AS SELECT row_number() over () as id, geom::GEOMETRY as geom
+#  FROM st_generatepoints({min_x: 0, min_y: 0, max_x: 10000, max_y: 10000}::BOX_2D, 1000, 1337) as pts(geom);
+#
+#statement ok
+#CREATE INDEX my_idx ON points USING RTREE(geom);
+#
+#query II
+#SELECT * FROM points WHERE geom && ST_MakeEnvelope(0, 0, 500, 500);
+#----
+#351	POINT (359.812940005213 406.6655575297773)
+#472	POINT (169.11179292947054 129.24372218549252)
+#775	POINT (173.61568519845605 455.52933821454644)

--- a/test/sql/join/spatial_join_extra_pred.test
+++ b/test/sql/join/spatial_join_extra_pred.test
@@ -1,0 +1,18 @@
+require spatial
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t1 AS
+SELECT
+    ST_Buffer(ST_Point(x, y), 5) as geom,
+    (y * 50) + x // 10 as id
+FROM
+    generate_series(500, 750, 10) r1(x),
+    generate_series(500, 750, 10) r2(y);
+
+query II
+EXPLAIN SELECT * FROM t1 p1 JOIN t1 p2 ON ST_Intersects(p1.geom, p2.geom) where ST_Area(ST_Intersection(p1.geom, p2.geom)) > 0;
+----
+physical_plan	<REGEX>:.*SPATIAL_JOIN.*Join Type: INNER.*


### PR DESCRIPTION
This PR applies patches from upstream v1.5, including lazy generation of coordinate system definitions.
It also
- Fixes an issue where r-tree index scans didnt see transaction-local data
- Generalizes bounding-box computation across the index code
- Improves the spatial-join optimizer to pull up additional arbitrary expressions as filters when performing inner joins, making it possible to apply spatial joins in more situations.