### PR TITLE
Remove legacy geometry type + fix progress bar in GDAL

### DIFF
--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -459,7 +459,7 @@ public:
 	CPLStringList dataset_sibling;
 	CPLStringList dataset_drivers;
 
-	int64_t estimated_cardinality = 0;
+	int64_t estimated_cardinality = -1;
 	unordered_set<idx_t> geometry_columns = {};
 
 	bool can_filter = false;
@@ -1011,13 +1011,16 @@ auto Progress(ClientContext &context, const FunctionData *b_data, const GlobalTa
 	auto &gstate = g_state->Cast<GlobalState>();
 
 	if (bdata.estimated_cardinality < 0) {
+		return -1.0;
+	}
+	if (bdata.estimated_cardinality == 0) {
 		return 0.0;
 	}
 
 	const auto count = static_cast<double>(gstate.features_read.load());
 	const auto total = static_cast<double>(bdata.estimated_cardinality);
 
-	return MinValue(100.0 * (total / count), 100.0);
+	return MinValue(100.0 * (count / total), 100.0);
 }
 
 //------------------------------------------------------------------------------------------------------------------

--- a/src/spatial/modules/main/spatial_functions.hpp
+++ b/src/spatial/modules/main/spatial_functions.hpp
@@ -25,9 +25,4 @@ public:
 	static void Box2DToVarchar(Vector &source, Vector &result, idx_t count);
 };
 
-struct CastParameters;
-struct SpatialCasts {
-	bool FromLegacyGeometryCast(Vector &source, Vector &result, idx_t count, CastParameters &params);
-};
-
 } // namespace duckdb

--- a/src/spatial/modules/main/spatial_functions_cast.cpp
+++ b/src/spatial/modules/main/spatial_functions_cast.cpp
@@ -116,183 +116,6 @@ struct GeometryCasts {
 	}
 
 	//------------------------------------------------------------------------------------------------------------------
-	// LEGACY_GEOMETRY -> GEOMETRY
-	//------------------------------------------------------------------------------------------------------------------
-	static uint32_t FromLegacyGeometryRequiredSize(BinaryReader &reader) {
-
-		reader.Skip(sizeof(uint8_t)); // type
-		const auto flags = reader.Read<uint8_t>();
-		reader.Skip(sizeof(uint16_t));
-		reader.Skip(sizeof(uint32_t)); // padding
-
-		// Parse flags
-		const auto has_z = (flags & 0x01) != 0;
-		const auto has_m = (flags & 0x02) != 0;
-		const auto has_bbox = (flags & 0x04) != 0;
-
-		const auto format_v1 = (flags & 0x40) != 0;
-		const auto format_v0 = (flags & 0x80) != 0;
-
-		if (format_v1 || format_v0) {
-			// Unsupported version, throw an error
-			throw NotImplementedException(
-			    "This geometry seems to be written with a newer version of the DuckDB spatial library that is not "
-			    "compatible with this version. Please upgrade your DuckDB installation.");
-		}
-
-		if (has_bbox) {
-			// Skip past bbox if present
-			reader.Skip(sizeof(float) * 2 * (2 + has_z + has_m));
-		}
-
-		// Create root geometry
-		const auto vert_width = (2 + has_z + has_m) * sizeof(double);
-
-		uint32_t total_size = 0;
-		while (!reader.IsAtEnd()) {
-
-			const auto type = static_cast<sgl::geometry_type>(reader.Read<uint32_t>() + 1);
-			const auto size = reader.Read<uint32_t>();
-
-			// Endianness + type
-			total_size += sizeof(uint8_t) + sizeof(uint32_t);
-
-			switch (type) {
-			case sgl::geometry_type::POINT: {
-				// Points have a fixed size
-				reader.Skip(size * vert_width);
-				total_size += vert_width;
-			} break;
-			case sgl::geometry_type::LINESTRING: {
-				reader.Skip(size * vert_width);
-				total_size += sizeof(uint32_t) + (size * vert_width);
-			} break;
-			case sgl::geometry_type::POLYGON: {
-				total_size += sizeof(uint32_t); // ring count
-				auto ring_reader = reader;
-				reader.Skip(size * sizeof(uint32_t) + (size % 2) * sizeof(uint32_t));
-				for (uint32_t ring_idx = 0; ring_idx < size; ring_idx++) {
-					const auto ring_size = ring_reader.Read<uint32_t>();
-					reader.Skip(vert_width * ring_size);
-					total_size += sizeof(uint32_t) + ring_size * vert_width;
-				}
-			} break;
-			case sgl::geometry_type::MULTI_POINT:
-			case sgl::geometry_type::MULTI_LINESTRING:
-			case sgl::geometry_type::MULTI_POLYGON: {
-			case sgl::geometry_type::GEOMETRY_COLLECTION: {
-				total_size += sizeof(uint32_t); // item count
-			} break;
-			default:
-				throw InvalidInputException("Unsupported geometry type in legacy geometry!");
-			}
-			}
-		}
-		return total_size;
-	}
-
-	static void FromLegacyGeometryConversion(BinaryReader &reader, BinaryWriter &writer) {
-		reader.Skip(sizeof(uint8_t)); // type
-		const auto flags = reader.Read<uint8_t>();
-		reader.Skip(sizeof(uint16_t));
-		reader.Skip(sizeof(uint32_t)); // padding
-
-		// Parse flags
-		const auto has_z = (flags & 0x01) != 0;
-		const auto has_m = (flags & 0x02) != 0;
-		const auto has_bbox = (flags & 0x04) != 0;
-
-		const auto format_v1 = (flags & 0x40) != 0;
-		const auto format_v0 = (flags & 0x80) != 0;
-
-		if (format_v1 || format_v0) {
-			// Unsupported version, throw an error
-			throw NotImplementedException(
-			    "This geometry seems to be written with a newer version of the DuckDB spatial library that is not "
-			    "compatible with this version. Please upgrade your DuckDB installation.");
-		}
-
-		if (has_bbox) {
-			// Skip past bbox if present
-			reader.Skip(sizeof(float) * 2 * (2 + has_z + has_m));
-		}
-
-		// Create root geometry
-		const auto vert_width = (2 + has_z + has_m) * sizeof(double);
-
-		while (!reader.IsAtEnd()) {
-			const auto type = static_cast<sgl::geometry_type>(reader.Read<uint32_t>() + 1);
-			const auto size = reader.Read<uint32_t>();
-
-			// Write endianness + type
-			const auto meta = static_cast<uint32_t>(type) + (has_z ? 1 : 0) * 1000 + (has_m ? 2 : 0) * 1000;
-
-			writer.Write<uint8_t>(1); // little endian
-			writer.Write<uint32_t>(meta);
-
-			switch (type) {
-			case sgl::geometry_type::POINT: {
-				if (size == 0) {
-					constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
-					constexpr double empty[4] = {nan, nan, nan, nan};
-					writer.Copy(reinterpret_cast<const char *>(empty), vert_width);
-				} else {
-					const auto vert_data = reader.Reserve(vert_width);
-					writer.Copy(vert_data, vert_width);
-				}
-			} break;
-			case sgl::geometry_type::LINESTRING: {
-				writer.Write<uint32_t>(size);
-
-				const auto vert_size = vert_width * size;
-				const auto vert_data = reader.Reserve(vert_size);
-
-				writer.Copy(vert_data, vert_size);
-			} break;
-			case sgl::geometry_type::POLYGON: {
-				writer.Write<uint32_t>(size); // ring count
-				auto ring_reader = reader;
-				reader.Skip(size * sizeof(uint32_t) + (size % 2) * sizeof(uint32_t));
-				for (uint32_t ring_idx = 0; ring_idx < size; ring_idx++) {
-					const auto ring_size = ring_reader.Read<uint32_t>();
-					writer.Write<uint32_t>(ring_size);
-
-					const auto vert_size = vert_width * ring_size;
-					const auto vert_data = reader.Reserve(vert_size);
-
-					writer.Copy(vert_data, vert_size);
-				}
-			} break;
-			case sgl::geometry_type::MULTI_POINT:
-			case sgl::geometry_type::MULTI_LINESTRING:
-			case sgl::geometry_type::MULTI_POLYGON:
-			case sgl::geometry_type::GEOMETRY_COLLECTION: {
-				writer.Write<uint32_t>(size); // item count
-			} break;
-			default:
-				throw InvalidInputException("Unsupported geometry type in legacy geometry!");
-			}
-		}
-	}
-
-	static bool FromLegacyGeometryCast(Vector &source, Vector &result, idx_t count, CastParameters &params) {
-		UnaryExecutor::Execute<string_t, string_t>(source, result, count, [&](const string_t &old_blob) {
-			BinaryReader reader(old_blob.GetDataUnsafe(), old_blob.GetSize());
-
-			const auto new_size = FromLegacyGeometryRequiredSize(reader);
-			auto new_blob = StringVector::EmptyString(result, new_size);
-
-			reader.Reset();
-			BinaryWriter writer(new_blob.GetDataWriteable(), new_blob.GetSize());
-			FromLegacyGeometryConversion(reader, writer);
-
-			new_blob.Finalize();
-			return new_blob;
-		});
-		return true;
-	}
-
-	//------------------------------------------------------------------------------------------------------------------
 	// Register
 	//------------------------------------------------------------------------------------------------------------------
 	static void Register(ExtensionLoader &loader) {
@@ -300,11 +123,6 @@ struct GeometryCasts {
 
 		// Geometry -> BLOB is explicitly castable
 		loader.RegisterCastFunction(geom_type, LogicalType::BLOB, DefaultCasts::ReinterpretCast);
-
-		// Also allow casting from LEGACY_GEOMETRY to GEOMETRY (Implicit)
-		loader.RegisterCastFunction(GeoTypes::LEGACY_GEOMETRY(), geom_type, FromLegacyGeometryCast, 1);
-
-		// TODO: And the other way around?
 	}
 };
 
@@ -1078,11 +896,6 @@ struct BoxCasts {
 };
 
 } // namespace
-
-// Re-export this function
-bool SpatialCasts::FromLegacyGeometryCast(Vector &source, Vector &result, idx_t count, CastParameters &params) {
-	return GeometryCasts::FromLegacyGeometryCast(source, result, count, params);
-}
 
 //======================================================================================================================
 // Vector Operations

--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -4953,10 +4953,7 @@ struct ST_GeomFromWKB {
 	//------------------------------------------------------------------------------------------------------------------
 	// Documentation
 	//------------------------------------------------------------------------------------------------------------------
-	static constexpr auto DESCRIPTION = R"(
-		Deserializes a GEOMETRY from a WKB encoded blob
-	)";
-	static constexpr auto EXAMPLE = "";
+	// TODO
 
 	//------------------------------------------------------------------------------------------------------------------
 	// Register
@@ -5008,20 +5005,22 @@ struct ST_GeomFromWKB {
 			builder.SetTag("category", "conversion");
 		});
 
+		/*
 		FunctionBuilder::RegisterScalar(loader, "ST_GeomFromWKB", [](ScalarFunctionBuilder &builder) {
-			builder.AddVariant([](ScalarFunctionVariantBuilder &variant) {
-				variant.AddParameter("blob", LogicalType::BLOB);
-				variant.SetReturnType(LogicalType::GEOMETRY());
+		    builder.AddVariant([](ScalarFunctionVariantBuilder &variant) {
+		        variant.AddParameter("blob", LogicalType::BLOB);
+		        variant.SetReturnType(LogicalType::GEOMETRY());
 
-				variant.SetInit(LocalState::Init);
-				variant.SetFunction(ExecuteGeometry);
-			});
+		        variant.SetInit(LocalState::Init);
+		        variant.SetFunction(ExecuteGeometry);
+		    });
 
-			builder.SetDescription(DESCRIPTION);
-			builder.SetExample(EXAMPLE);
-			builder.SetTag("ext", "spatial");
-			builder.SetTag("category", "conversion");
+		    builder.SetDescription(DESCRIPTION);
+		    builder.SetExample(EXAMPLE);
+		    builder.SetTag("ext", "spatial");
+		    builder.SetTag("category", "conversion");
 		});
+		*/
 	}
 };
 

--- a/src/spatial/spatial_types.cpp
+++ b/src/spatial/spatial_types.cpp
@@ -73,12 +73,6 @@ LogicalType GeoTypes::POLYGON_3D() {
 	return type;
 }
 
-LogicalType GeoTypes::LEGACY_GEOMETRY() {
-	auto blob_type = LogicalType(LogicalTypeId::BLOB);
-	blob_type.SetAlias("GEOMETRY");
-	return blob_type;
-}
-
 LogicalType GeoTypes::CreateEnumType(const string &name, const vector<string> &members) {
 	auto varchar_vector = Vector(LogicalType::VARCHAR, members.size());
 	auto varchar_data = FlatVector::GetData<string_t>(varchar_vector);
@@ -186,9 +180,6 @@ void GeoTypes::Register(ExtensionLoader &loader) {
 
 	// Box2DF
 	loader.RegisterType("BOX_2DF", GeoTypes::BOX_2DF());
-
-	// GEOMETRY
-	loader.RegisterType("GEOMETRY", GeoTypes::LEGACY_GEOMETRY());
 }
 
 } // namespace duckdb

--- a/src/spatial/spatial_types.hpp
+++ b/src/spatial/spatial_types.hpp
@@ -30,9 +30,6 @@ struct GeoTypes {
 	static LogicalType BOX_2D();
 	static LogicalType BOX_2DF();
 
-	// Old geometry type (pre v1.5)
-	static LogicalType LEGACY_GEOMETRY();
-
 	static void Register(ExtensionLoader &loader);
 
 	static LogicalType CreateEnumType(const string &name, const vector<string> &members);


### PR DESCRIPTION
With https://github.com/duckdb/duckdb/pull/21020#event-23068425198 in we don't need to keep the old type around anymore. 

Also fixes incorrect handling of the query progress in `ST_Read`, closing https://github.com/duckdb/duckdb-spatial/issues/454