### PR TITLE
Improve spatial filter pushdown in `ST_Read` + fix rtree scan issue

### DIFF
--- a/src/spatial/index/rtree/rtree_index_plan_scan.cpp
+++ b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
@@ -218,7 +218,7 @@ public:
 
 		unordered_set<string> spatial_predicates = {
 		    "ST_Equals",   "ST_Intersects", "ST_Touches",   "ST_Crosses",          "ST_Within", "ST_Contains",
-		    "ST_Overlaps", "ST_Covers",     "ST_CoveredBy", "ST_ContainsProperly", "&&",        "ST_IntersectsExtent"};
+		    "ST_Overlaps", "ST_Covers",     "ST_CoveredBy", "ST_ContainsProperly", "&&",        "ST_Intersects_Extent"};
 
 		table_info.BindIndexes(context, RTreeIndex::TYPE_NAME);
 

--- a/src/spatial/index/rtree/rtree_index_plan_scan.cpp
+++ b/src/spatial/index/rtree/rtree_index_plan_scan.cpp
@@ -224,7 +224,7 @@ public:
 
 		for (auto &index : table_info.GetIndexes().Indexes()) {
 			if (!index.IsBound() || RTreeIndex::TYPE_NAME != index.GetIndexType()) {
-				return false;
+				continue;
 			}
 
 			auto &index_entry = index.Cast<RTreeIndex>();

--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -29,6 +29,8 @@
 #include "cpl_vsi_virtual.h"
 #include "duckdb/common/types/geometry_crs.hpp"
 #include "duckdb/main/settings.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 #include "spatial/spatial_settings.hpp"
 #include "spatial/modules/proj/proj_module.hpp"
 
@@ -395,7 +397,6 @@ private:
 
 class DuckDBFileSystemPrefix final : public ClientContextState {
 public:
-
 	// Use an intentionally leaked heap-allocated mutex to avoid static destruction order issues.
 	// A static mutex (either class-level or function-local) can be destroyed before the last
 	// DuckDBFileSystemPrefix destructor runs during program teardown, causing
@@ -448,7 +449,6 @@ private:
 	string client_prefix;
 	unique_ptr<DuckDBFileSystemHandler> fs_handler;
 };
-
 
 //======================================================================================================================
 // GDAL READ
@@ -746,7 +746,9 @@ auto Pushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data, 
 		}
 
 		// The set of geometry predicates that can be optimized using the bounding box
-		static constexpr const char *geometry_predicates[2] = {"&&", "st_intersects_extent"};
+		static constexpr const char *geometry_predicates[12] = {
+		    "ST_Equals",   "ST_Intersects", "ST_Touches",   "ST_Crosses",          "ST_Within", "ST_Contains",
+		    "ST_Overlaps", "ST_Covers",     "ST_CoveredBy", "ST_ContainsProperly", "&&",        "ST_Intersects_Extent"};
 
 		auto found = false;
 		for (const auto &name : geometry_predicates) {
@@ -763,10 +765,8 @@ auto Pushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data, 
 		const auto lhs_kind = func.children[0]->GetExpressionType();
 		const auto rhs_kind = func.children[1]->GetExpressionType();
 
-		const auto lhs_is_const =
-		    lhs_kind == ExpressionType::VALUE_CONSTANT && rhs_kind == ExpressionType::BOUND_COLUMN_REF;
-		const auto rhs_is_const =
-		    rhs_kind == ExpressionType::VALUE_CONSTANT && lhs_kind == ExpressionType::BOUND_COLUMN_REF;
+		const auto lhs_is_const = lhs_kind == ExpressionType::VALUE_CONSTANT;
+		const auto rhs_is_const = rhs_kind == ExpressionType::VALUE_CONSTANT;
 
 		if (lhs_is_const == rhs_is_const) {
 			// Both sides are constant or both sides are column refs
@@ -774,7 +774,37 @@ auto Pushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data, 
 		}
 
 		auto &constant_expr = func.children[lhs_is_const ? 0 : 1]->Cast<BoundConstantExpression>();
-		auto &geometry_expr = func.children[lhs_is_const ? 1 : 0]->Cast<BoundColumnRefExpression>();
+		auto &geometry_expr = func.children[lhs_is_const ? 1 : 0];
+
+		auto found_geom_expr = false;
+		auto multi_geom_expr = false;
+		ExpressionIterator::VisitExpression<BoundColumnRefExpression>(
+		    *geometry_expr, [&](const BoundColumnRefExpression &ref) {
+			    if (found_geom_expr) {
+				    multi_geom_expr = true;
+				    return;
+			    }
+			    if (ref.binding.table_index != get.table_index) {
+				    // Not from the same table
+				    return;
+			    }
+
+			    const auto &col_ids = get.GetColumnIds();
+			    const auto &col = col_ids[ref.binding.column_index];
+
+			    if (!col.HasPrimaryIndex()) {
+				    return;
+			    }
+			    if (col.GetPrimaryIndex() != *bdata.geometry_columns.begin()) {
+				    return;
+			    }
+			    found_geom_expr = true;
+		    });
+
+		if (!found_geom_expr || multi_geom_expr) {
+			// No geometry column ref found or multiple geometry refs found
+			continue;
+		}
 
 		if (constant_expr.value.type().id() != LogicalTypeId::GEOMETRY) {
 			// Constant is not geometry
@@ -784,7 +814,7 @@ auto Pushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data, 
 			// Constant is NULL
 			continue;
 		}
-		if (geometry_expr.alias != "geom") {
+		if (geometry_expr->return_type.id() != LogicalTypeId::GEOMETRY) {
 			// Not the geometry column
 			continue;
 		}
@@ -803,7 +833,13 @@ auto Pushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data, 
 		// Set the index so we can remove it later
 		// We can __ONLY__ do this if the filter predicate is "&&" or "st_intersects_extent"
 		// as other predicates may require exact geometry evaluation, the filter cannot be fully removed
-		geom_filter_idx = expr_idx;
+		for (auto &name : {"&&", "ST_Intersects_Extent"}) {
+			if (StringUtil::CIEquals(func.function.name.c_str(), name)) {
+				geom_filter_idx = expr_idx;
+				break;
+			}
+		}
+
 		break;
 	}
 
@@ -1055,6 +1091,22 @@ auto ReplacementScan(ClientContext &, ReplacementScanInput &input, optional_ptr<
 	return nullptr;
 }
 
+//------------------------------------------------------------------------------------------------------------------
+// TO STRING
+//------------------------------------------------------------------------------------------------------------------
+auto ToString(TableFunctionToStringInput &input) -> InsertionOrderPreservingMap<string> {
+	auto &bdata = input.bind_data->Cast<BindData>();
+	InsertionOrderPreservingMap<string> result;
+	result.insert("Layer", to_string(bdata.layer_idx));
+
+	if (bdata.has_filter) {
+		result.insert("Filter (MinX, MinY, MaxX, MaxY)",
+		              StringUtil::Format("(%f, %f, %f, %f)", bdata.layer_filter.MinX, bdata.layer_filter.MinY,
+		                                 bdata.layer_filter.MaxX, bdata.layer_filter.MaxY));
+	}
+	return result;
+}
+
 //----------------------------------------------------------------------------------------------------------------------
 // REGISTER
 //----------------------------------------------------------------------------------------------------------------------
@@ -1112,6 +1164,7 @@ void Register(ExtensionLoader &loader) {
 	read_func.statistics = Statistics;
 	read_func.table_scan_progress = Progress;
 	read_func.pushdown_complex_filter = Pushdown;
+	read_func.to_string = ToString;
 
 	read_func.named_parameters["open_options"] = LogicalType::LIST(LogicalType::VARCHAR);
 	read_func.named_parameters["allowed_drivers"] = LogicalType::LIST(LogicalType::VARCHAR);

--- a/src/spatial/modules/main/spatial_functions_scalar.cpp
+++ b/src/spatial/modules/main/spatial_functions_scalar.cpp
@@ -6481,10 +6481,10 @@ struct ST_Intersects {
 };
 
 //======================================================================================================================
-// ST_IntersectsExtent
+// ST_Intersects_Extent
 //======================================================================================================================
 
-struct ST_IntersectsExtent {
+struct ST_Intersects_Extent {
 
 	//------------------------------------------------------------------------------------------------------------------
 	// GEOMETRY
@@ -9527,7 +9527,7 @@ void RegisterSpatialScalarFunctions(ExtensionLoader &loader) {
 	ST_InteriorRingN::Register(loader);
 	ST_InterpolatePoint::Register(loader);
 	ST_Intersects::Register(loader);
-	ST_IntersectsExtent::Register(loader);
+	ST_Intersects_Extent::Register(loader);
 	ST_IsClosed::Register(loader);
 	ST_IsEmpty::Register(loader);
 	ST_Length::Register(loader);

--- a/src/spatial/modules/proj/proj_module.cpp
+++ b/src/spatial/modules/proj/proj_module.cpp
@@ -223,7 +223,7 @@ struct ST_Transform {
 		}
 
 		static void Serialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
-				  const ScalarFunction &function) {
+		                      const ScalarFunction &function) {
 			auto &bind_data = bind_data_p->Cast<TypedBindData>();
 			serializer.WritePropertyWithDefault(100, "normalize", bind_data.normalize);
 			serializer.WritePropertyWithDefault(101, "source", bind_data.source_crs);
@@ -324,7 +324,6 @@ struct ST_Transform {
 
 		return std::move(result);
 	}
-
 
 	//------------------------------------------------------------------------------------------------------------------
 	// Local State

--- a/src/spatial/operators/spatial_join_optimizer.cpp
+++ b/src/spatial/operators/spatial_join_optimizer.cpp
@@ -16,26 +16,37 @@ namespace duckdb {
 
 // All of these imply bounding box intersection
 static const case_insensitive_set_t spatial_predicate_map = {
-    "&&",           "ST_IntersectsExtent", "ST_Equals",         "ST_Intersects", "ST_Touches",
-    "ST_Crosses",   "ST_Within",           "ST_Contains",       "ST_Overlaps",   "ST_Covers",
-    "ST_CoveredBy", "ST_ContainsProperly", "ST_WithinProperly", "ST_DWithin",
+    "&&",
+    "ST_Intersects_Extent",
+    "ST_Equals",
+    "ST_Intersects",
+    "ST_Touches",
+    "ST_Crosses",
+    "ST_Within",
+    "ST_Contains",
+    "ST_Overlaps",
+    "ST_Covers",
+    "ST_CoveredBy",
+    "ST_ContainsProperly",
+    "ST_WithinProperly",
+    "ST_DWithin",
 };
 
 static const case_insensitive_map_t<string> spatial_predicate_inverse_map = {
     {"ST_Equals", "ST_Equals"},
-    {"&&", "&&"},                                   // Symmetric
-    {"ST_IntersectsExtent", "ST_IntersectsExtent"}, // Symmetric
-    {"ST_Intersects", "ST_Intersects"},             // Symmetric
-    {"ST_Touches", "ST_Touches"},                   // Symmetric
-    {"ST_Crosses", "ST_Crosses"},                   // Symmetric
-    {"ST_Within", "ST_Contains"},                   // Inverse
-    {"ST_Contains", "ST_Within"},                   // Inverse
-    {"ST_Overlaps", "ST_Overlaps"},                 // Symmetric
-    {"ST_Covers", "ST_CoveredBy"},                  // Inverse
-    {"ST_CoveredBy", "ST_Covers"},                  // Inverse
-    {"ST_WithinProperly", "ST_ContainsProperly"},   // Inverse
-    {"ST_ContainsProperly", "ST_WithinProperly"},   // Inverse
-    {"ST_DWithin", "ST_DWithin"},                   // Symmetric (when distance is constant)
+    {"&&", "&&"},                                     // Symmetric
+    {"ST_Intersects_Extent", "ST_Intersects_Extent"}, // Symmetric
+    {"ST_Intersects", "ST_Intersects"},               // Symmetric
+    {"ST_Touches", "ST_Touches"},                     // Symmetric
+    {"ST_Crosses", "ST_Crosses"},                     // Symmetric
+    {"ST_Within", "ST_Contains"},                     // Inverse
+    {"ST_Contains", "ST_Within"},                     // Inverse
+    {"ST_Overlaps", "ST_Overlaps"},                   // Symmetric
+    {"ST_Covers", "ST_CoveredBy"},                    // Inverse
+    {"ST_CoveredBy", "ST_Covers"},                    // Inverse
+    {"ST_WithinProperly", "ST_ContainsProperly"},     // Inverse
+    {"ST_ContainsProperly", "ST_WithinProperly"},     // Inverse
+    {"ST_DWithin", "ST_DWithin"},                     // Symmetric (when distance is constant)
 };
 
 static bool HasInversePredicate(const string &func_name) {

--- a/test/sql/gdal/gdal_filter_pushdown.test
+++ b/test/sql/gdal/gdal_filter_pushdown.test
@@ -1,0 +1,25 @@
+require spatial
+
+statement ok
+COPY (
+	SELECT row_number() OVER () as id, point::GEOMETRY
+	FROM st_generatepoints({min_x: 0, min_y: 0, max_x: 100, max_y: 100}::BOX_2D, 10_000, 1337)
+) TO '__TEST_DIR__/pts.fgb' WITH (FORMAT GDAL, DRIVER 'FlatGeoBuf', CRS 'EPSG:4326');
+
+
+# Test that we can push down the filter to GDAL
+query II
+EXPLAIN SELECT count(*) FROM st_read('__TEST_DIR__/pts.fgb') WHERE geom && ST_MakeEnvelope(45, 45, 65, 65);
+----
+physical_plan	<REGEX>:.*MinX, MinY.*
+
+query II
+EXPLAIN SELECT count(*) FROM st_read('__TEST_DIR__/pts.fgb') WHERE st_intersects_extent(geom, ST_MakeEnvelope(45, 45, 65, 65));
+----
+physical_plan	<REGEX>:.*MinX, MinY.*
+
+# For exact predicates, we push down the bbox, but the exact predicate is still evaluated in DuckDB
+query II
+EXPLAIN SELECT count(*) FROM st_read('__TEST_DIR__/pts.fgb') WHERE st_intersects(geom, ST_MakeEnvelope(45, 45, 65, 65));
+----
+physical_plan	<REGEX>:.*ST_Intersects.*MinX, MinY.*

--- a/test/sql/index/rtree_multiple_index.test
+++ b/test/sql/index/rtree_multiple_index.test
@@ -1,0 +1,23 @@
+require spatial
+
+# Create a table with 10_000 random points, where the table also has an ART primary key index
+statement ok
+CREATE TABLE IF NOT EXISTS t1 (
+            id          LONG PRIMARY KEY,
+            geom        GEOMETRY
+);
+
+statement ok
+INSERT INTO t1(id, geom)
+SELECT row_number() OVER (), point
+FROM st_generatepoints({min_x: 0, min_y: 0, max_x: 100, max_y: 100}::BOX_2D, 10_000, 1337);
+
+# Create an index on the table.
+statement ok
+CREATE INDEX my_idx ON t1 USING RTREE (geom);
+
+# RTREE is used
+query II
+EXPLAIN SELECT count(*) FROM t1 WHERE ST_Within(geom, ST_MakeEnvelope(45, 45, 65, 65));
+----
+physical_plan	<REGEX>:.*RTREE_INDEX_SCAN.*


### PR DESCRIPTION
This PR makes the spatial filter pushdown into `ST_Read` more robust so that it can handle cases where the filtered table column is wrapped in additional expressions (such as a cast).

We now also enable bounding-box pushdown for all spatial predicates, but only _remove_ the filter entirely if its `&&` or `ST_Intersects_Extent`.

Also implements `to_string` for `ST_Read` so that the layer index and any pushed down bbox filter is printed as part of the `EXPLAIN` output.

Also fixes a bug causing R-Tree index scans to not be used if there is another index type on the table (such as a primary key).


Closes #769 
Closes [#728](https://github.com/duckdb/duckdb-spatial/issues/728#issuecomment-4071376986)