### PR TITLE
fix(gdal): st_read_meta returns empty results for /vsi* paths

### DIFF
--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -1172,6 +1172,17 @@ struct ST_Read_Meta {
 		// TODO: Add metadata, domains, relationships
 
 		// Get the filename list
+		const auto file_name = input.inputs[0].GetValue<string>();
+
+		// If the path starts with /vsi (GDAL virtual filesystem), pass it directly to GDAL.
+		// MultiFileReader doesn't understand /vsizip/, /vsicurl/, etc. and silently returns
+		// an empty file list, causing st_read_meta to return 0 rows.
+		if (StringUtil::StartsWith(file_name, "/vsi")) {
+			vector<OpenFileInfo> files;
+			files.emplace_back(file_name);
+			return make_uniq_base<FunctionData, BindData>(std::move(files));
+		}
+
 		const auto mfreader = MultiFileReader::Create(input.table_function);
 		const auto mflist = mfreader->CreateFileList(context, input.inputs[0], FileGlobOptions::ALLOW_EMPTY);
 		return make_uniq_base<FunctionData, BindData>(mflist->GetAllFiles());


### PR DESCRIPTION
## Summary

`st_read_meta()` silently returns 0 rows when called with GDAL virtual filesystem paths (`/vsizip/`, `/vsicurl/`, `/vsigs/`, etc.). This is because the `Bind` function uses `MultiFileReader::CreateFileList()` which doesn't understand `/vsi*` prefixes and returns an empty list (masked by `ALLOW_EMPTY`).

This is inconsistent with `st_read()`, which correctly handles `/vsi*` paths by passing them directly to GDAL via `GetPrefix()`.

## The Fix

When the input path starts with `/vsi`, bypass `MultiFileReader` and pass the path directly to GDAL — matching the existing behavior of `st_read()`. Non-`/vsi` paths continue to use `MultiFileReader` for glob expansion.

**Before:**
```sql
-- Returns 0 rows silently
SELECT * FROM st_read_meta('/vsizip//vsicurl/https://example.com/data.zip');
```

**After:**
```sql
-- Returns full metadata (layers, geometry types, CRS, fields)
SELECT * FROM st_read_meta('/vsizip//vsicurl/https://example.com/data.zip');
```

## Root Cause

In `gdal_module.cpp`, the `ST_Read_Meta::Bind` function:

```cpp
const auto mfreader = MultiFileReader::Create(input.table_function);
const auto mflist = mfreader->CreateFileList(context, input.inputs[0], FileGlobOptions::ALLOW_EMPTY);
return make_uniq_base<FunctionData, BindData>(mflist->GetAllFiles());
```

`MultiFileReader::CreateFileList` tries to resolve `/vsizip/...` through DuckDB's VFS layer, fails, and returns an empty list. The `ALLOW_EMPTY` flag suppresses the error.

Meanwhile, `st_read` avoids this by using `GDALClientContextState::GetPrefix()` which already has explicit `/vsi` handling (line 446):

```cpp
if (StringUtil::StartsWith(value, "/vsi")) {
    return value;  // Pass through to GDAL unchanged
}
```

## Use Case

This enables listing layers in remote archives without downloading them:

```sql
-- Discover layers in a remote shapefile zip
SELECT unnest(layers) FROM st_read_meta('/vsizip//vsicurl/https://storage.googleapis.com/bucket/data.zip');

-- Works with signed URLs using the {braces} syntax
SELECT * FROM st_read_meta('/vsizip/{/vsicurl/https://...?X-Goog-Signature=...}/layer.shp');
```

Previously the only workaround was calling `ogrinfo` as an external process, or downloading the file locally first.

## Related Issues

- #45 — Original request for metadata reading (led to `st_read_meta`)
- #729 — Reports `st_read_meta` crashes/returns 0 rows for some formats
- #544 — `st_read_meta()` crash reports