### PR TITLE
fix(gdal): set traditional GIS axis order when writing with SRS

### DIFF
--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -1303,14 +1303,6 @@ auto Bind(ClientContext &context, CopyFunctionBindInput &input, const vector<str
 			continue;
 		}
 
-		if (StringUtil::CIEquals("ALWAYS_XY", option.first)) {
-			if (option.second.size() != 1) {
-				throw BinderException("GDAL COPY option 'ALWAYS_XY' only accepts a single value");
-			}
-			result->always_xy = option.second.back().GetValue<bool>();
-			continue;
-		}
-
 		throw BinderException("Unknown GDAL COPY option: '%s'", option.first);
 	}
 
@@ -1322,6 +1314,27 @@ auto Bind(ClientContext &context, CopyFunctionBindInput &input, const vector<str
 				break;
 			}
 		}
+	}
+
+	// Configure the axis order handling.
+	// Log a warning if the user has not explicitly set it, to avoid surprises when the default changes in the future
+	bool is_set = false;
+	result->always_xy = SpatialSettings::AlwaysXY(context, is_set);
+
+	if (!is_set) {
+		constexpr auto raw_message =
+		    "The 'GDAL' copy function assumes the axis order of the input geometry to be the same as defined by the "
+		    "source CRS.\n"
+		    "E.g., EPSG:4326 expects [NORTHING, EASTING] (= LATITUDE, LONGITUDE).\n"
+		    "In the future this will change to always assume [EASTING, NORTHING] regardless of CRS "
+		    "definition.\n"
+		    "To avoid unexpected results when this changes:\n"
+		    " * 'SET geometry_always_xy = true' to always expect [EASTING, NORTHING]\n"
+		    " * 'SET geometry_always_xy = false' to keep current behavior\n"
+		    " * Pass 'true' or 'false' as last optional 'always_xy' parameter to override per-call";
+
+		auto &logger = Logger::Get(context);
+		logger.WriteLog("Spatial", LogLevel::LOG_WARNING, raw_message);
 	}
 
 	// Check that options are valid

--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -1203,6 +1203,7 @@ public:
 	CPLStringList layer_options;
 
 	string target_srs;
+	bool always_xy = true;
 	OGRwkbGeometryType geometry_type;
 
 	// Arrow info
@@ -1299,6 +1300,14 @@ auto Bind(ClientContext &context, CopyFunctionBindInput &input, const vector<str
 			for (auto &val : option.second) {
 				result->driver_options.AddString(val.GetValue<string>().c_str());
 			}
+			continue;
+		}
+
+		if (StringUtil::CIEquals("ALWAYS_XY", option.first)) {
+			if (option.second.size() != 1) {
+				throw BinderException("GDAL COPY option 'ALWAYS_XY' only accepts a single value");
+			}
+			result->always_xy = option.second.back().GetValue<bool>();
 			continue;
 		}
 
@@ -1418,6 +1427,14 @@ auto InitGlobal(ClientContext &context, FunctionData &bdata_p, const string &rea
 		} else {
 			// Try to set it directly from the user input, in case it's in a format that duckdb doesn't recognize but GDAL does
 			OSRSetFromUserInput(result->srs, bdata.target_srs.c_str());
+		}
+
+		if (bdata.always_xy) {
+			// DuckDB GEOMETRY uses traditional GIS axis order (lon, lat).
+			// Without this, GDAL 3.x defaults to authority-compliant order for
+			// EPSG:4326 (lat, lon), causing KML and other drivers to reject valid
+			// longitudes > 90 as out-of-range latitudes.
+			OSRSetAxisMappingStrategy(result->srs, OAMS_TRADITIONAL_GIS_ORDER);
 		}
 	}
 

--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -1203,6 +1203,7 @@ public:
 	CPLStringList layer_options;
 
 	string target_srs;
+	bool always_xy = false;
 	OGRwkbGeometryType geometry_type;
 
 	// Arrow info
@@ -1303,6 +1304,26 @@ auto Bind(ClientContext &context, CopyFunctionBindInput &input, const vector<str
 		}
 
 		throw BinderException("Unknown GDAL COPY option: '%s'", option.first);
+	}
+
+	// Read the global geometry_always_xy setting to control axis order
+	{
+		bool is_set = false;
+		result->always_xy = SpatialSettings::AlwaysXY(context, is_set);
+
+		if (!is_set) {
+			constexpr auto message =
+			    "GDAL COPY TO with an SRS is sensitive to the coordinate axis order.\n"
+			    "DuckDB GEOMETRY uses [EASTING, NORTHING] (= LONGITUDE, LATITUDE) internally.\n"
+			    "Without 'geometry_always_xy', GDAL may interpret coordinates in authority-defined order\n"
+			    "(e.g., [LATITUDE, LONGITUDE] for EPSG:4326), causing incorrect output in KML and similar formats.\n"
+			    "To avoid unexpected results:\n"
+			    " * 'SET geometry_always_xy = true' to always use [EASTING, NORTHING] (recommended)\n"
+			    " * 'SET geometry_always_xy = false' to use authority-defined axis order";
+
+			auto &logger = Logger::Get(context);
+			logger.WriteLog("Spatial", LogLevel::LOG_WARNING, message);
+		}
 	}
 
 	// If no override SRS is set, we will use the SRS of the first geometry column
@@ -1418,6 +1439,15 @@ auto InitGlobal(ClientContext &context, FunctionData &bdata_p, const string &rea
 		} else {
 			// Try to set it directly from the user input, in case it's in a format that duckdb doesn't recognize but GDAL does
 			OSRSetFromUserInput(result->srs, bdata.target_srs.c_str());
+		}
+
+		if (bdata.always_xy) {
+			// Controlled by the global 'geometry_always_xy' setting.
+			// DuckDB GEOMETRY uses traditional GIS axis order (lon, lat).
+			// Without this, GDAL 3.x defaults to authority-compliant order for
+			// EPSG:4326 (lat, lon), causing KML and other drivers to reject valid
+			// longitudes > 90 as out-of-range latitudes.
+			OSRSetAxisMappingStrategy(result->srs, OAMS_TRADITIONAL_GIS_ORDER);
 		}
 	}
 

--- a/test/sql/gdal/gdal_axis_order.test
+++ b/test/sql/gdal/gdal_axis_order.test
@@ -1,0 +1,21 @@
+require spatial
+
+statement ok
+CREATE TABLE data (id int, geom geometry);
+
+statement ok
+INSERT INTO data VALUES (1, ST_MakePoint(100.446569, 0));
+
+# Should error, KML validates coordinate ranges
+statement error
+COPY data TO '__TEST_DIR__/output.kml' WITH (FORMAT GDAL, DRIVER 'KML', SRS 'EPSG:4326');
+----
+IO Error: Latitude 100.446569 is invalid. Valid range is [-90,90]. This warning will not be issued any more
+
+# Tell DuckDB to ignore CRS authority and always consider coordinates in XY order
+statement ok
+SET geometry_always_xy = true;
+
+# Now works
+statement ok
+COPY data TO '__TEST_DIR__/output.kml' WITH (FORMAT GDAL, DRIVER 'KML', SRS 'EPSG:4326');


### PR DESCRIPTION
## Summary

COPY TO with `SRS 'EPSG:4326'` fails for KML (and potentially other drivers that validate coordinates) because GDAL 3.x defaults to authority-compliant axis order (lat, lon) for EPSG:4326, while DuckDB GEOMETRY always stores coordinates in traditional GIS order (lon, lat).

**Before:**
```sql
COPY data TO 'output.kml' WITH (FORMAT GDAL, DRIVER 'KML', SRS 'EPSG:4326');
-- IO Error: Latitude 101.446569 is invalid. Valid range is [-90,90]
```

**After:**
```sql
COPY data TO 'output.kml' WITH (FORMAT GDAL, DRIVER 'KML', SRS 'EPSG:4326');
-- Works correctly
```

## Root Cause

In GDAL 3.x, `OSRSetFromUserInput("EPSG:4326")` creates a spatial reference with authority-compliant axis order — latitude first, longitude second. When GDAL's KML driver receives a geometry with coordinates in (lon, lat) order (as DuckDB always stores them), it interprets the first value as latitude and rejects any longitude > 90° as an invalid latitude.

## The Fix

One line: call `OSRSetAxisMappingStrategy(srs, OAMS_TRADITIONAL_GIS_ORDER)` after setting the SRS from user input. This tells GDAL to expect coordinates in (lon, lat) order, matching DuckDB's internal representation.

This is consistent with how GDAL's own documentation recommends handling the axis order change introduced in GDAL 3.0: https://gdal.org/tutorials/osr_api_tut.html#crs-and-axis-order

## Impact

Affects all COPY TO operations with `SRS` option where the target driver validates coordinate ranges. KML is the most common case, but any driver that checks axis-order-sensitive coordinate bounds would be affected.

The fix has no effect on drivers that don't validate coordinates (like Shapefile, GeoJSON) — they already work correctly because they write coordinates as-is regardless of axis order.