### PR TITLE
Aggregate & Join fixes

### DIFF
--- a/src/spatial/modules/geos/geos_serde.cpp
+++ b/src/spatial/modules/geos/geos_serde.cpp
@@ -335,7 +335,9 @@ GEOSGeom_t *GeosSerde::Deserialize(GEOSContextHandle_t ctx, ArenaAllocator &aren
                                    size_t buffer_size) {
 	// GEOS always does full copies of the data,
 	// so reset the arena after each deserialization
-	arena.Reset();
+	// TODO: Do this, for now we cant because some aggregates will reuse the arena for their own state
+	// and then we cant reset it
+	// arena.Reset();
 
 	// Deserialize the geometry
 	BinaryReader reader(buffer, buffer_size);

--- a/src/spatial/operators/spatial_join_optimizer.cpp
+++ b/src/spatial/operators/spatial_join_optimizer.cpp
@@ -151,6 +151,12 @@ static bool TrySwapComparisonJoin(OptimizerExtensionInput &input, unique_ptr<Log
 		return false;
 	}
 
+	if (cmp_join.HasProjectionMap() || filter.HasProjectionMap()) {
+		// We can't handle this right now.
+		// We need to recompute the projection maps, but it's a pain.
+		return false;
+	}
+
 	// Get the table indexes that are reachable from the left and right children
 	const auto &left_child = cmp_join.children[0];
 	const auto &right_child = cmp_join.children[1];


### PR DESCRIPTION
- Don't reset arena in geos aggregates, might be used by other aggregate functions in the same operator
- Don't perform comparison->spatial join swap if there are projection maps. Will have to fix in the future.