### PR TITLE
Fix ST_READ hang on MapInfo TAB files

### DIFF
--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -78,6 +78,7 @@ public:
 			while (bytes_left > 0) {
 				const auto bytes_read = file_handle->Read(bytes_data, bytes_left);
 				if (bytes_read == 0) {
+					is_eof = true;
 					break;
 				}
 				bytes_left -= bytes_read;


### PR DESCRIPTION
## Summary

- `ST_READ` and `st_read_meta` hang indefinitely on MapInfo TAB files (and potentially other text-based GDAL formats that use `CPLReadLineL`)
- Root cause: `DuckDBFileHandle::Eof()` never returns `TRUE` for local files because `is_eof` is only set inside a `catch` block, but local file reads signal EOF by returning 0 bytes **without throwing**
- Fix: set `is_eof = true` when `Read()` returns 0 bytes with data still remaining (one line)

## Root cause analysis

The GDAL MapInfo driver reads the `.tab` text file line-by-line via `TAB_CSLLoad → CPLReadLineL → CPLReadLine3L → VSIFReadL`. The read loop checks `VSIFEofL()` (→ `DuckDBFileHandle::Eof()`) to know when to stop.

Stack trace from a hung process confirms the infinite loop:
```
TABFile::Open → TAB_CSLLoad → CPLReadLineL → CPLReadLine3L
  → DuckDBFileHandle::Read → LocalFileSystem::Read → read()
```

The current `Read()` implementation only sets `is_eof` in the exception handler (line 87-91), but `LocalFileSystem::Read()` returns 0 at EOF without throwing. So `Eof()` always returns `FALSE` and the GDAL read loop never terminates.

## Test plan

- [x] Created a MapInfo TAB file with `ogr2ogr`, confirmed hang with unpatched build (timeout after 10s on a 1-row file)
- [x] Applied fix, confirmed `ST_READ` and `st_read_meta` both return correct results immediately
- [x] Tested on both `main` and `v1.5-variegata` branches
- [x] Verified standalone GDAL reads the same file correctly (the issue is specific to DuckDB's VSI filesystem handler)