### PR TITLE
fix: support GDAL driver-prefixed URLs (WFS, OAPIF, etc.)

### DIFF
--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -429,11 +429,39 @@ public:
 		VSIFileManager::RemoveHandler(client_prefix);
 	}
 
+	// Check if a path looks like a GDAL driver-prefixed URL (e.g., "WFS:https://...", "OAPIF:https://...")
+	// These need to be passed directly to GDALOpenEx without our custom VSI prefix.
+	static bool IsGDALDriverPrefixedURL(const string &value) {
+		auto colon_pos = value.find(':');
+		if (colon_pos == string::npos || colon_pos == 0 || colon_pos > 20) {
+			return false;
+		}
+		// Check that the prefix is all uppercase letters (GDAL driver names are uppercase)
+		for (idx_t i = 0; i < colon_pos; i++) {
+			char c = value[i];
+			if (!StringUtil::CharacterIsAlpha(c) || c != StringUtil::CharacterToUpper(c)) {
+				return false;
+			}
+		}
+		// Check that after the colon there is a URL scheme (http:// or https://)
+		// This excludes database connection strings like "PG:dbname=..." which are not supported.
+		auto rest = value.substr(colon_pos + 1);
+		return StringUtil::StartsWith(rest, "http://") || StringUtil::StartsWith(rest, "https://");
+	}
+
 	string AddPrefix(const string &value) const {
 		// If the user explicitly asked for a VSI prefix, we don't add our own
 		if (StringUtil::StartsWith(value, "/vsi")) {
 			if (!Settings::Get<EnableExternalAccessSetting>(context)) {
 				throw PermissionException("Cannot open file '%s' with VSI prefix: External access is disabled", value);
+			}
+			return value;
+		}
+		// If the path is a GDAL driver-prefixed URL (e.g., "WFS:https://..."), pass it through directly
+		if (IsGDALDriverPrefixedURL(value)) {
+			if (!Settings::Get<EnableExternalAccessSetting>(context)) {
+				throw PermissionException(
+				    "Cannot open file '%s' with GDAL driver prefix: External access is disabled", value);
 			}
 			return value;
 		}
@@ -1774,11 +1802,20 @@ auto Bind(ClientContext &context, TableFunctionBindInput &input, vector<LogicalT
 	types.push_back(LogicalType::VARCHAR);
 	types.push_back(LogicalType::LIST(GetLayerType()));
 
-	const auto mf_reader = MultiFileReader::Create(input.table_function);
-	const auto mf_inputs = mf_reader->CreateFileList(context, input.inputs[0], FileGlobOptions::ALLOW_EMPTY);
-
 	auto result = make_uniq<BindData>();
-	result->files = mf_inputs->GetAllFiles();
+
+	// For /vsi* paths and GDAL driver-prefixed URLs (e.g., "WFS:https://..."),
+	// bypass MultiFileReader since these are not local file globs.
+	auto raw_path = input.inputs[0].GetValue<string>();
+	if (StringUtil::StartsWith(raw_path, "/vsi") ||
+	    DuckDBFileSystemPrefix::IsGDALDriverPrefixedURL(raw_path)) {
+		result->files.emplace_back(std::move(raw_path));
+	} else {
+		const auto mf_reader = MultiFileReader::Create(input.table_function);
+		const auto mf_inputs = mf_reader->CreateFileList(context, input.inputs[0], FileGlobOptions::ALLOW_EMPTY);
+		result->files = mf_inputs->GetAllFiles();
+	}
+
 	return std::move(result);
 }
 

--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -1806,13 +1806,23 @@ auto Bind(ClientContext &context, TableFunctionBindInput &input, vector<LogicalT
 
 	// For /vsi* paths and GDAL driver-prefixed URLs (e.g., "WFS:https://..."),
 	// bypass MultiFileReader since these are not local file globs.
-	auto raw_path = input.inputs[0].GetValue<string>();
-	if (StringUtil::StartsWith(raw_path, "/vsi") ||
-	    DuckDBFileSystemPrefix::IsGDALDriverPrefixedURL(raw_path)) {
-		result->files.emplace_back(std::move(raw_path));
+	// We must check the input type first because MultiFileReader::CreateFunctionSet
+	// adds a VARCHAR[] overload, and GetValue<string>() on a LIST would return
+	// the string representation of the list, not an actual path.
+	auto &input_val = input.inputs[0];
+	if (input_val.type().id() == LogicalTypeId::VARCHAR) {
+		auto raw_path = input_val.GetValue<string>();
+		if (StringUtil::StartsWith(raw_path, "/vsi") ||
+		    DuckDBFileSystemPrefix::IsGDALDriverPrefixedURL(raw_path)) {
+			result->files.emplace_back(std::move(raw_path));
+		} else {
+			const auto mf_reader = MultiFileReader::Create(input.table_function);
+			const auto mf_inputs = mf_reader->CreateFileList(context, input_val, FileGlobOptions::ALLOW_EMPTY);
+			result->files = mf_inputs->GetAllFiles();
+		}
 	} else {
 		const auto mf_reader = MultiFileReader::Create(input.table_function);
-		const auto mf_inputs = mf_reader->CreateFileList(context, input.inputs[0], FileGlobOptions::ALLOW_EMPTY);
+		const auto mf_inputs = mf_reader->CreateFileList(context, input_val, FileGlobOptions::ALLOW_EMPTY);
 		result->files = mf_inputs->GetAllFiles();
 	}
 

--- a/test/sql/gdal/gdal_vsi.test
+++ b/test/sql/gdal/gdal_vsi.test
@@ -16,3 +16,21 @@ statement error
 SELECT COUNT(*) FROM st_read('/vsigzip/__WORKING_DIRECTORY__/test/data/amsterdam_roads_50.geojson.gz');
 ----
 with VSI prefix: External access is disabled
+
+# Test that GDAL driver-prefixed URLs are blocked when external access is disabled
+statement error
+SELECT COUNT(*) FROM st_read('WFS:https://example.com/wfs');
+----
+with GDAL driver prefix: External access is disabled
+
+# Test that OAPIF driver-prefixed URLs are blocked when external access is disabled
+statement error
+SELECT COUNT(*) FROM st_read('OAPIF:https://example.com/collections');
+----
+with GDAL driver prefix: External access is disabled
+
+# Test that st_read_meta also blocks driver-prefixed URLs when external access is disabled
+statement error
+SELECT * FROM st_read_meta('WFS:https://example.com/wfs');
+----
+with GDAL driver prefix: External access is disabled


### PR DESCRIPTION
## Summary

- GDAL driver-prefixed URLs like `WFS:https://...` and `OAPIF:https://...` were being mangled by `AddPrefix()` prepending `/vsiduckdb-<UUID>/`, making them unrecognizable to `GDALOpenEx`
- Added detection for the `DRIVERNAME:http(s)://` pattern (all-uppercase driver name followed by an HTTP URL) and passes these through directly, matching the existing behavior for `/vsi*` paths
- Also fixes `st_read_meta` to bypass `MultiFileReader` for these URLs and `/vsi*` paths, so they reach GDAL properly instead of being resolved as local file globs
- Security: driver-prefixed URLs are blocked when `enable_external_access=false`, same as `/vsi*` paths

This enables queries like:
```sql
SELECT * FROM st_read('WFS:https://ahocevar.com/geoserver/wfs', layer='topp:states');
SELECT * FROM st_read('OAPIF:https://demo.pygeoapi.io/master', layer='lakes');
SELECT * FROM st_read_meta('WFS:https://ahocevar.com/geoserver/wfs');
```

## Test plan
- [x] Added tests for `st_read` blocking WFS/OAPIF URLs when external access is disabled
- [x] Added test for `st_read_meta` blocking driver-prefixed URLs when external access is disabled
- [x] All 178 existing GDAL test assertions pass
- [x] Manually verified `st_read` with live WFS and OAPIF endpoints
- [x] Manually verified `st_read_meta` with live WFS endpoint