### PR TITLE
feat: add ST_SymDifference

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -124,6 +124,7 @@
 | [`ST_Simplify`](#st_simplify) | Returns a simplified version of the geometry |
 | [`ST_SimplifyPreserveTopology`](#st_simplifypreservetopology) | Returns a simplified version of the geometry that preserves topology |
 | [`ST_StartPoint`](#st_startpoint) | Returns the start point of a LINESTRING. |
+| [`ST_SymDifference`](#st_symdifference) | Returns a geometry that represents the portions of two geometries that do not intersect |
 | [`ST_TileEnvelope`](#st_tileenvelope) | The `ST_TileEnvelope` scalar function generates tile envelope rectangular polygons from specified zoom level and tile indices. |
 | [`ST_Touches`](#st_touches) | Returns true if the geometries touch |
 | [`ST_Transform`](#st_transform) | Transforms a geometry between two coordinate systems |
@@ -2610,6 +2611,21 @@ POINT_2D ST_StartPoint (line LINESTRING_2D)
 #### Description
 
 Returns the start point of a LINESTRING.
+
+----
+
+### ST_SymDifference
+
+
+#### Signatures
+
+```sql
+GEOMETRY ST_SymDifference(geom1 GEOMETRY, geom2 GEOMETRY)
+```
+
+#### Description
+
+Returns a geometry that represents the portions of geom1 and geom2 that do not intersect.
 
 ----
 

--- a/src/spatial/modules/geos/geos_module.cpp
+++ b/src/spatial/modules/geos/geos_module.cpp
@@ -2233,6 +2233,41 @@ struct ST_SimplifyPreserveTopology {
 	}
 };
 
+struct ST_SymDifference {
+	static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
+		auto &lstate = LocalState::ResetAndGet(state);
+
+		BinaryExecutor::Execute<string_t, string_t, string_t>(
+		    args.data[0], args.data[1], result, args.size(), [&](const string_t &lhs_blob, const string_t &rhs_blob) {
+			    const auto lhs = lstate.Deserialize(lhs_blob);
+			    const auto rhs = lstate.Deserialize(rhs_blob);
+			    const auto union_geom = lhs.get_union(rhs);
+			    const auto intersection_geom = lhs.get_intersection(rhs);
+			    const auto sym_diff = union_geom.get_difference(intersection_geom);
+
+			    return lstate.Serialize(result, sym_diff);
+		    });
+	}
+
+	static void Register(ExtensionLoader &loader) {
+		FunctionBuilder::RegisterScalar(loader, "ST_SymDifference", [](ScalarFunctionBuilder &func) {
+			func.AddVariant([](ScalarFunctionVariantBuilder &variant) {
+				variant.AddParameter("geom1", LogicalType::GEOMETRY());
+				variant.AddParameter("geom2", LogicalType::GEOMETRY());
+				variant.SetReturnType(LogicalType::GEOMETRY());
+
+				variant.SetInit(LocalState::Init);
+				variant.SetFunction(Execute);
+				variant.CanThrowErrors();
+			});
+
+			func.SetDescription("Returns the symmetric difference of two geometries");
+			func.SetTag("ext", "spatial");
+			func.SetTag("category", "construction");
+		});
+	}
+};
+
 struct ST_Touches : SymmetricPreparedBinaryFunction<ST_Touches> {
 	static bool ExecutePredicateNormal(const GeosGeometry &lhs, const GeosGeometry &rhs) {
 		return lhs.touches(rhs);
@@ -3186,6 +3221,7 @@ void RegisterGEOSModule(ExtensionLoader &loader) {
 	ST_ShortestLine::Register(loader);
 	ST_Simplify::Register(loader);
 	ST_SimplifyPreserveTopology::Register(loader);
+	ST_SymDifference::Register(loader);
 	ST_Touches::Register(loader);
 	ST_Union::Register(loader);
 	ST_VoronoiDiagram::Register(loader);

--- a/test/sql/geos/st_symdifference.test
+++ b/test/sql/geos/st_symdifference.test
@@ -1,0 +1,41 @@
+# name: test/sql/geos/st_symdifference.test
+# group: [geos]
+
+require spatial
+
+# Standard test
+
+query I
+SELECT ST_AsText(ST_SymDifference(
+    ST_GeomFromText('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))'),
+    ST_GeomFromText('POLYGON((1 1, 3 1, 3 3, 1 3, 1 1))')
+));
+----
+MULTIPOLYGON (((0 0, 0 2, 1 2, 1 1, 2 1, 2 0, 0 0)), ((1 3, 3 3, 3 1, 2 1, 2 2, 1 2, 1 3)))
+
+# Identical test
+
+query I
+SELECT ST_IsEmpty(ST_SymDifference(
+    ST_GeomFromText('LINESTRING(0 0, 5 5)'),
+    ST_GeomFromText('LINESTRING(0 0, 5 5)')
+));
+----
+true
+
+# Disjoint test 
+
+query I
+SELECT ST_AsText(ST_SymDifference(
+    ST_GeomFromText('POINT(0 0)'),
+    ST_GeomFromText('POINT(5 5)')
+));
+----
+MULTIPOINT (0 0, 5 5)
+
+# NULL test
+
+query I
+SELECT ST_SymDifference(NULL, ST_GeomFromText('POINT(0 0)'));
+----
+NULL


### PR DESCRIPTION
### Description

This PR adds the ST_SymDifference scalar function to the spatial extension as discussed in #785 

### Changes

Implemented ST_SymDifference 

Added SQL logic tests in test/sql/geos/st_symdifference.test

Updated documentation in docs/functions.md