### PR TITLE
fix: only suppress FID column when it duplicates an existing attribute field

### DIFF
--- a/src/spatial/modules/gdal/gdal_module.cpp
+++ b/src/spatial/modules/gdal/gdal_module.cpp
@@ -646,12 +646,15 @@ auto Bind(ClientContext &ctx, TableFunctionBindInput &input, vector<LogicalType>
 		// Get the layer geometry type if available
 		result->layer_type = OGR_L_GetGeomType(layer);
 
-		// Check FID column
+		// Only suppress the FID if the layer already exposes it as a regular attribute field
 		const auto fid_col = OGR_L_GetFIDColumn(layer);
 		if (fid_col && strcmp(fid_col, "") != 0) {
-			// Do not include the explicit FID if we already have it as a column
-			result->layer_options.AddString("INCLUDE_FID=NO");
+			const auto layer_defn = OGR_L_GetLayerDefn(layer);
+			if (OGR_FD_GetFieldIndex(layer_defn, fid_col) >= 0) {
+				result->layer_options.AddString("INCLUDE_FID=NO");
+			}
 		}
+
 		const auto geom_col_name = OGR_L_GetGeometryColumn(layer);
 
 		// Get the arrow stream

--- a/test/sql/gdal/st_read_gdb.test
+++ b/test/sql/gdal/st_read_gdb.test
@@ -16,7 +16,7 @@ Not implemented Error: Can only insert a LineString/MultiLineString/CircularStri
 statement ok
 COPY (SELECT ST_Point(1,2) as geom, 10 as i) TO '__TEST_DIR__/test.gdb' WITH (FORMAT 'GDAL', DRIVER 'OpenFileGDB', GEOMETRY_TYPE 'POINT');
 
-query II
+query III
 FROM st_read('__TEST_DIR__/test.gdb');
 ----
-10	POINT (1 2)
+1	10	POINT (1 2)

--- a/test/sql/gdal/st_read_gpkg_fid.test
+++ b/test/sql/gdal/st_read_gpkg_fid.test
@@ -1,0 +1,17 @@
+require spatial
+
+# Create a GeoPackage with three features
+statement ok
+COPY (
+    SELECT id, ST_GeomFromText('POINT (' || id || ' ' || id || ')') AS geom
+    FROM (VALUES (1), (2), (3)) AS t(id)
+) TO '__TEST_DIR__/test_fid.gpkg'
+WITH (FORMAT GDAL, DRIVER 'GPKG');
+
+# Read it back and verify the fid column is present with correct values
+query II
+SELECT fid, id FROM st_read('__TEST_DIR__/test_fid.gpkg') ORDER BY fid;
+----
+1	1
+2	2
+3	3


### PR DESCRIPTION
## Summary
- Only set `INCLUDE_FID=NO` when the FID column name already exists as a regular attribute field (`OGR_FD_GetFieldIndex`), preventing duplicate columns for formats like GeoJSON
- For formats where the FID is separate (GeoPackage, GDB, etc.), the FID column now correctly appears in output

Closes #790

## Test plan
- [x] New `st_read_gpkg_fid.test` — round-trips a GeoPackage and asserts `fid` column is present with correct values
- [x] Updated `st_read_gdb.test` — expects `OBJECTID` FID column in output
- [x] All 11 GDAL tests pass, including existing GeoJSON tests (no duplication)