### PR TITLE
Fix error handling in geos module

### DIFF
--- a/src/spatial/modules/geos/geos_module.cpp
+++ b/src/spatial/modules/geos/geos_module.cpp
@@ -2424,6 +2424,8 @@ struct GeosUnaryAggFunction {
 	static void Initialize(STATE &state) {
 		state.geom = nullptr;
 		state.context = GEOS_init_r();
+		GEOSContext_setErrorMessageHandler_r(
+		    state.context, [](const char *message, void *) { throw InvalidInputException(message); }, nullptr);
 	}
 
 	template <class STATE, class OP>
@@ -2579,6 +2581,8 @@ struct ST_Union_Agg {
 		const auto state_ptr = new (state_mem) State();
 		auto &state = *state_ptr;
 		state.context = GEOS_init_r();
+		GEOSContext_setErrorMessageHandler_r(
+		    state.context, [](const char *message, void *) { throw InvalidInputException(message); }, nullptr);
 	}
 
 	static void Update(Vector inputs[], AggregateInputData &aggr, idx_t, Vector &state_vec, idx_t count) {
@@ -2778,6 +2782,8 @@ struct GEOSCoverageAggFunction {
 		const auto state_ptr = new (state_mem) State();
 		auto &state = *state_ptr;
 		state.context = GEOS_init_r();
+		GEOSContext_setErrorMessageHandler_r(
+		    state.context, [](const char *message, void *) { throw InvalidInputException(message); }, nullptr);
 	}
 
 	static void Absorb(Vector &state_vec, Vector &combined, AggregateInputData &aggr_input_data, idx_t count) {

--- a/test/sql/geos/geos_agg_error_handling.test
+++ b/test/sql/geos/geos_agg_error_handling.test
@@ -1,0 +1,14 @@
+require spatial
+
+# Test that GEOS aggregate functions properly report errors instead of crashing
+# when encountering invalid geometries. Previously, the GEOS error handler was not
+# registered for aggregate function contexts, causing nullptr dereferences.
+
+# ST_Union_Agg with self-intersecting (bowtie) polygons
+statement error
+SELECT ST_Union_Agg(geom) FROM (VALUES
+  ('POLYGON ((0 0, 10 10, 10 0, 0 10, 0 0))'::geometry),
+  ('POLYGON ((20 20, 30 30, 30 20, 20 30, 20 20))'::geometry)
+) AS t(geom);
+----
+Invalid Input Error


### PR DESCRIPTION
Some geometries currently crash DuckDB because error handlers are not correctly registered.

Crash dump (caused by `result_union` being nullptr):

```
  thread #1, name = 'duck-server', stop reason = signal SIGSEGV: address not mapped to object
    frame #0: 0x0000aaaae30b2998 duck-server`GEOSGeomTypeId_r + 56
    frame #1: 0x0000aaaae38efa40 duck-server`duckdb::GeosSerde::GetRequiredSize(ctx=0x0000fffaecbf4900, geom=0x0000000000000000) at geos_serde.cpp:51:20
    frame #2: 0x0000aaaae38eba50 duck-server`duckdb::(anonymous namespace)::ST_Union_Agg::Finalize(duckdb::Vector&, duckdb::AggregateInputData&, duckdb::Vector&, unsigned long, unsigned long) [inlined] duckdb::(anonymous namespace)::ST_Union_Agg::Serialize(context=0x0000fffaecbf4900, result=0x0000fffaec870138, geom=0x0000000000000000) at geos_module.cpp:2524:21
    frame #3: 0x0000aaaae38eba44 duck-server`duckdb::(anonymous namespace)::ST_Union_Agg::Finalize(state_vec=<unavailable>, aggr_input_data=<unavailable>, result=0x0000fffaec870138, count=156, offset=<unavailable>) at geos_module.cpp:2650:27
    frame #4: 0x0000aaaadfa4de40 duck-server`duckdb::RowOperations::FinalizeStates(state=0x0000fffdce030950, layout=0x0000fffdce030828, addresses=<unavailable>, result=0x0000fffdce030b90, aggr_idx=1) at row_aggregate.cpp:117:3
    frame #5: 0x0000aaaadfa45400 duck-server`duckdb::RadixHTLocalSourceState::Scan(this=0x0000fffdce030800, sink=0x0000fffe4a9a0000, gstate=<unavailable>, chunk=0x0000fffdce140000) at radix_partitioned_hashtable.cpp:916:2
    frame #6: 0x0000aaaadfa44b98 duck-server`duckdb::RadixHTLocalSourceState::ExecuteTask(this=<unavailable>, sink=<unavailable>, gstate=<unavailable>, chunk=<unavailable>) at radix_partitioned_hashtable.cpp:826:3 [artificial]
    frame #7: 0x0000aaaadfa457f4 duck-server`duckdb::RadixPartitionedHashTable::GetData(this=<unavailable>, context=<unavailable>, chunk=0x0000fffdce140000, sink_p=0x0000fffe4a9a0000, input=0x0000fffe76109d18) const at radix_partitioned_hashtable.cpp:1014:10
    frame #8: 0x0000aaaadf8b58b0 duck-server`duckdb::PhysicalHashAggregate::GetDataInternal(this=0x0000fffdd61d60b8, context=0x0000fffaf6c700b0, chunk=0x0000fffdce140000, input=0x0000fffe76109d98) const at physical_hash_aggregate.cpp:881:26
    frame #9: 0x0000aaaadfc27bd8 duck-server`duckdb::PipelineExecutor::FetchFromSource(duckdb::DataChunk&) [inlined] duckdb::PipelineExecutor::GetData(this=0x0000fffaf6c70000, chunk=0x0000fffdce140000, input=0x0000fffe76109d98) at pipeline_executor.cpp:504:26
    frame #10: 0x0000aaaadfc27bbc duck-server`duckdb::PipelineExecutor::FetchFromSource(this=0x0000fffaf6c70000, result=0x0000fffdce140000) at pipeline_executor.cpp:530:13
    frame #11: 0x0000aaaadfc23a0c duck-server`duckdb::PipelineExecutor::Execute(this=0x0000fffaf6c70000, max_chunks=50) at pipeline_executor.cpp:230:21
    frame #12: 0x0000aaaadfc233d4 duck-server`duckdb::PipelineTask::ExecuteTask(this=0x0000fffd4fd353a0, mode=<unavailable>) at pipeline.cpp:41:33
    frame #13: 0x0000aaaadfc1b000 duck-server`duckdb::ExecutorTask::Execute(this=0x0000fffd4fd353a0, mode=PROCESS_PARTIAL) at executor_task.cpp:52:18
    frame #14: 0x0000aaaadfc2bbc0 duck-server`duckdb::TaskScheduler::ExecuteForever(this=0x0000fffef2421f40, marker=0x0000fffef2730158) at task_scheduler.cpp:307:32
    frame #15: 0x0000ffff9acb1ae0
    frame #16: 0x0000ffff9af1595c
```